### PR TITLE
ci: fix codecov token upload

### DIFF
--- a/.github/workflows/maven-code-coverage.yml
+++ b/.github/workflows/maven-code-coverage.yml
@@ -26,7 +26,7 @@ jobs:
         distribution: 'temurin'
     - name: Test with Maven
       run: mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test jacoco:report
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true


### PR DESCRIPTION
CodeCov action apparently does not perform the reporting upload with the necessary token when manually triggered.