### PR TITLE
API: removing payload type from generic signatures

### DIFF
--- a/src/main/java/tech/illuin/pipeline/PipelineContainer.java
+++ b/src/main/java/tech/illuin/pipeline/PipelineContainer.java
@@ -11,14 +11,14 @@ import java.util.Map;
  */
 public final class PipelineContainer
 {
-    private final Map<String, Pipeline<?, ?>> pipelines;
+    private final Map<String, Pipeline<?>> pipelines;
 
     public PipelineContainer()
     {
         this.pipelines = new HashMap<>();
     }
 
-    public Pipeline<?, ?> get(String id)
+    public Pipeline<?> get(String id)
     {
         return this.pipelines.get(id);
     }
@@ -28,15 +28,15 @@ public final class PipelineContainer
         return this.pipelines.containsKey(id);
     }
 
-    public PipelineContainer register(Pipeline<?, ?> pipeline)
+    public PipelineContainer register(Pipeline<?> pipeline)
     {
         this.pipelines.put(pipeline.id(), pipeline);
         return this;
     }
 
-    public PipelineContainer register(Collection<Pipeline<?, ?>> pipelines)
+    public PipelineContainer register(Collection<Pipeline<?>> pipelines)
     {
-        for (Pipeline<?, ?> pipeline : pipelines)
+        for (Pipeline<?> pipeline : pipelines)
             this.register(pipeline);
         return this;
     }

--- a/src/main/java/tech/illuin/pipeline/PipelineResult.java
+++ b/src/main/java/tech/illuin/pipeline/PipelineResult.java
@@ -6,6 +6,6 @@ import tech.illuin.pipeline.step.result.Result;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public record PipelineResult<P>(
-    Output<P> output
+public record PipelineResult(
+    Output output
 ) implements Result {}

--- a/src/main/java/tech/illuin/pipeline/builder/ComponentBuilder.java
+++ b/src/main/java/tech/illuin/pipeline/builder/ComponentBuilder.java
@@ -12,12 +12,12 @@ import java.util.Optional;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public abstract class ComponentBuilder<T, I, P, CD, CC extends Annotation>
+public abstract class ComponentBuilder<T, I, CD, CC extends Annotation>
 {
-    protected final RunnerCompiler<CC, T, I, P> compiler;
+    protected final RunnerCompiler<CC, T, I> compiler;
     private final Class<CC> configType;
 
-    protected ComponentBuilder(Class<CC> configType, MethodArgumentResolver<T, I, P> methodArgumentResolver, List<MethodValidator> methodValidators)
+    protected ComponentBuilder(Class<CC> configType, MethodArgumentResolver<T, I> methodArgumentResolver, List<MethodValidator> methodValidators)
     {
         this.compiler = new GenericRunnerCompiler<>(configType, methodArgumentResolver, methodValidators);
         this.configType = configType;

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/CompiledMethod.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/CompiledMethod.java
@@ -9,8 +9,8 @@ import java.util.List;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public record CompiledMethod<C extends Annotation, T, I, P>(
+public record CompiledMethod<C extends Annotation, T, I>(
     Method method,
-    List<MethodArgumentMapper<T, I, P>> mappers,
+    List<MethodArgumentMapper<T, I>> mappers,
     C config
 ) {}

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/GenericRunnerCompiler.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/GenericRunnerCompiler.java
@@ -16,20 +16,20 @@ import java.util.List;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class GenericRunnerCompiler<C extends Annotation, T, I, P> implements RunnerCompiler<C, T, I, P>
+public class GenericRunnerCompiler<C extends Annotation, T, I> implements RunnerCompiler<C, T, I>
 {
     private final Class<C> configType;
-    private final MethodArgumentResolver<T, I, P> argumentResolver;
+    private final MethodArgumentResolver<T, I> argumentResolver;
     private final List<MethodValidator> methodValidators;
 
     private static final Logger logger = LoggerFactory.getLogger(GenericRunnerCompiler.class);
 
-    public GenericRunnerCompiler(Class<C> configType, MethodArgumentResolver<T, I, P> argumentResolver)
+    public GenericRunnerCompiler(Class<C> configType, MethodArgumentResolver<T, I> argumentResolver)
     {
         this(configType, argumentResolver, Collections.emptyList());
     }
 
-    public GenericRunnerCompiler(Class<C> configType, MethodArgumentResolver<T, I, P> argumentResolver, List<MethodValidator> additionalValidators)
+    public GenericRunnerCompiler(Class<C> configType, MethodArgumentResolver<T, I> argumentResolver, List<MethodValidator> additionalValidators)
     {
         this.configType = configType;
         this.argumentResolver = argumentResolver;
@@ -37,7 +37,7 @@ public class GenericRunnerCompiler<C extends Annotation, T, I, P> implements Run
     }
 
     @Override
-    public CompiledMethod<C, T, I, P> compile(Object target)
+    public CompiledMethod<C, T, I> compile(Object target)
     {
         logger.trace("{}: Compiling runner-based " + this.configType.getSimpleName() + " with target type " + target.getClass().getName(), this);
 
@@ -74,13 +74,13 @@ public class GenericRunnerCompiler<C extends Annotation, T, I, P> implements Run
         return candidates;
     }
 
-    private List<MethodArgumentMapper<T, I, P>> compileArguments(MethodCandidate<C> candidate)
+    private List<MethodArgumentMapper<T, I>> compileArguments(MethodCandidate<C> candidate)
     {
-        List<MethodArgumentMapper<T, I, P>> mappers = new ArrayList<>();
+        List<MethodArgumentMapper<T, I>> mappers = new ArrayList<>();
         Parameter[] parameters = candidate.method().getParameters();
         for (Parameter parameter : parameters)
         {
-            MethodArgumentMapper<T, I, P> mapper = this.argumentResolver.resolveMapper(parameter);
+            MethodArgumentMapper<T, I> mapper = this.argumentResolver.resolveMapper(parameter);
             mappers.add(mapper);
         }
         return mappers;

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/RunnerCompiler.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/RunnerCompiler.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Annotation;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface RunnerCompiler<C extends Annotation, T, I, P>
+public interface RunnerCompiler<C extends Annotation, T, I>
 {
-    CompiledMethod<C, T, I, P> compile(Object target);
+    CompiledMethod<C, T, I> compile(Object target);
 }

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/MethodArgumentResolver.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/MethodArgumentResolver.java
@@ -10,11 +10,11 @@ import java.util.Set;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface MethodArgumentResolver<T, I, P>
+public interface MethodArgumentResolver<T, I>
 {
     Set<Class<?>> ANNOTATIONS = Set.of(
         Input.class, Object.class, Payload.class, Current.class, Latest.class, Context.class
     );
 
-    MethodArgumentMapper<T, I, P> resolveMapper(Parameter parameter);
+    MethodArgumentMapper<T, I> resolveMapper(Parameter parameter);
 }

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ComponentTagMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ComponentTagMapperFactory.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class ComponentTagMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class ComponentTagMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -17,7 +17,7 @@ public class ComponentTagMapperFactory<T, I, P> implements MethodArgumentMapperF
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         return args -> {

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ContextKeyMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ContextKeyMapperFactory.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class ContextKeyMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class ContextKeyMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -19,7 +19,7 @@ public class ContextKeyMapperFactory<T, I, P> implements MethodArgumentMapperFac
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Context context = (Context) category;
 

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ContextMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ContextMapperFactory.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class ContextMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class ContextMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -17,7 +17,7 @@ public class ContextMapperFactory<T, I, P> implements MethodArgumentMapperFactor
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         return args -> {

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/CurrentMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/CurrentMapperFactory.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class CurrentMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class CurrentMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -21,7 +21,7 @@ public class CurrentMapperFactory<T, I, P> implements MethodArgumentMapperFactor
 
     @Override
     @SuppressWarnings("unchecked")
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Current current = (Current) category;
         boolean filterByName = current.name() != null && !current.name().isBlank();

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/InputMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/InputMapperFactory.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class InputMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class InputMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -18,7 +18,7 @@ public class InputMapperFactory<T, I, P> implements MethodArgumentMapperFactory<
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         return MethodArguments::input;
     }

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/LatestMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/LatestMapperFactory.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class LatestMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class LatestMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -21,7 +21,7 @@ public class LatestMapperFactory<T, I, P> implements MethodArgumentMapperFactory
 
     @Override
     @SuppressWarnings("unchecked")
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Latest latest = (Latest) category;
         boolean filterByName = latest.name() != null && !latest.name().isBlank();

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/LogMarkerMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/LogMarkerMapperFactory.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class LogMarkerMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class LogMarkerMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -17,7 +17,7 @@ public class LogMarkerMapperFactory<T, I, P> implements MethodArgumentMapperFact
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         return args -> {

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/MethodArgumentMapper.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/MethodArgumentMapper.java
@@ -5,7 +5,7 @@ import tech.illuin.pipeline.builder.runner_compiler.argument_resolver.method_arg
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface MethodArgumentMapper<T, I, P>
+public interface MethodArgumentMapper<T, I>
 {
-    Object map(MethodArguments<T, I, P> arguments);
+    Object map(MethodArguments<T, I> arguments);
 }

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/MethodArgumentMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/MethodArgumentMapperFactory.java
@@ -6,9 +6,9 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface MethodArgumentMapperFactory<T, I, P>
+public interface MethodArgumentMapperFactory<T, I>
 {
     boolean canHandle(Annotation category, Class<?> parameterType);
 
-    MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter);
+    MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter);
 }

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ObjectMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ObjectMapperFactory.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class ObjectMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class ObjectMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -18,7 +18,7 @@ public class ObjectMapperFactory<T, I, P> implements MethodArgumentMapperFactory
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         return MethodArguments::object;
     }

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/OutputMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/OutputMapperFactory.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class OutputMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class OutputMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -17,7 +17,7 @@ public class OutputMapperFactory<T, I, P> implements MethodArgumentMapperFactory
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         return args -> {

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/PayloadMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/PayloadMapperFactory.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class PayloadMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class PayloadMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -18,7 +18,7 @@ public class PayloadMapperFactory<T, I, P> implements MethodArgumentMapperFactor
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         return MethodArguments::payload;
     }

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/PipelineTagMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/PipelineTagMapperFactory.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class PipelineTagMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class PipelineTagMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -17,7 +17,7 @@ public class PipelineTagMapperFactory<T, I, P> implements MethodArgumentMapperFa
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         return args -> {

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ResultViewMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ResultViewMapperFactory.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class ResultViewMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class ResultViewMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -17,7 +17,7 @@ public class ResultViewMapperFactory<T, I, P> implements MethodArgumentMapperFac
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         return args -> {

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ResultsMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/ResultsMapperFactory.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class ResultsMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class ResultsMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -17,7 +17,7 @@ public class ResultsMapperFactory<T, I, P> implements MethodArgumentMapperFactor
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         return args -> {

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/UIDGeneratorMapperFactory.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/mapper_factory/UIDGeneratorMapperFactory.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Parameter;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class UIDGeneratorMapperFactory<T, I, P> implements MethodArgumentMapperFactory<T, I, P>
+public class UIDGeneratorMapperFactory<T, I> implements MethodArgumentMapperFactory<T, I>
 {
     @Override
     public boolean canHandle(Annotation category, Class<?> parameterType)
@@ -17,7 +17,7 @@ public class UIDGeneratorMapperFactory<T, I, P> implements MethodArgumentMapperF
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> produce(Annotation category, Parameter parameter)
+    public MethodArgumentMapper<T, I> produce(Annotation category, Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         return args -> {

--- a/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/method_arguments/MethodArguments.java
+++ b/src/main/java/tech/illuin/pipeline/builder/runner_compiler/argument_resolver/method_arguments/MethodArguments.java
@@ -12,14 +12,14 @@ import tech.illuin.pipeline.step.result.Results;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public record MethodArguments<T, I, P>(
+public record MethodArguments<T, I>(
     T object,
     I input,
-    P payload,
-    Output<P> output,
+    Object payload,
+    Output output,
     ResultView resultView,
     Results results,
-    Context<P> context,
+    Context context,
     PipelineTag pipelineTag,
     ComponentTag componentTag,
     UIDGenerator uidGenerator,

--- a/src/main/java/tech/illuin/pipeline/context/ComponentContext.java
+++ b/src/main/java/tech/illuin/pipeline/context/ComponentContext.java
@@ -12,9 +12,9 @@ import java.util.Set;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class ComponentContext<P> implements LocalContext<P>
+public class ComponentContext implements LocalContext
 {
-    private final Context<P> globalContext;
+    private final Context globalContext;
     private final Object input;
     private final PipelineTag pipelineTag;
     private final ComponentTag componentTag;
@@ -22,7 +22,7 @@ public class ComponentContext<P> implements LocalContext<P>
     private final LogMarker marker;
 
     public ComponentContext(
-        Context<P> globalContext,
+        Context globalContext,
         Object input,
         PipelineTag pipelineTag,
         ComponentTag componentTag,
@@ -68,19 +68,19 @@ public class ComponentContext<P> implements LocalContext<P>
     }
 
     @Override
-    public Optional<Output<P>> parent()
+    public Optional<Output> parent()
     {
         return this.globalContext.parent();
     }
 
     @Override
-    public Context<P> set(String key, Object value)
+    public Context set(String key, Object value)
     {
         return this.globalContext.set(key, value);
     }
 
     @Override
-    public Context<P> copyFrom(Context<P> other)
+    public Context copyFrom(Context other)
     {
         return this.globalContext.copyFrom(other);
     }

--- a/src/main/java/tech/illuin/pipeline/context/Context.java
+++ b/src/main/java/tech/illuin/pipeline/context/Context.java
@@ -8,13 +8,13 @@ import java.util.Set;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface Context<P>
+public interface Context
 {
-    Optional<Output<P>> parent();
+    Optional<Output> parent();
 
-    Context<P> set(String key, Object value);
+    Context set(String key, Object value);
 
-    Context<P> copyFrom(Context<P> other);
+    Context copyFrom(Context other);
 
     boolean has(String key);
 

--- a/src/main/java/tech/illuin/pipeline/context/LocalContext.java
+++ b/src/main/java/tech/illuin/pipeline/context/LocalContext.java
@@ -8,7 +8,7 @@ import tech.illuin.pipeline.output.PipelineTag;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface LocalContext<P> extends Context<P>
+public interface LocalContext extends Context
 {
     Object input();
 

--- a/src/main/java/tech/illuin/pipeline/context/SimpleContext.java
+++ b/src/main/java/tech/illuin/pipeline/context/SimpleContext.java
@@ -10,9 +10,9 @@ import java.util.Set;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class SimpleContext<P> implements Context<P>
+public class SimpleContext implements Context
 {
-    private final Output<P> parent;
+    private final Output parent;
     private final Map<String, Object> metadata;
 
     public SimpleContext()
@@ -20,27 +20,27 @@ public class SimpleContext<P> implements Context<P>
         this(null);
     }
 
-    public SimpleContext(Output<P> parent)
+    public SimpleContext(Output parent)
     {
         this.parent = parent;
         this.metadata = new HashMap<>();
     }
 
     @Override
-    public Optional<Output<P>> parent()
+    public Optional<Output> parent()
     {
         return Optional.ofNullable(this.parent);
     }
 
     @Override
-    public Context<P> set(String key, Object value)
+    public Context set(String key, Object value)
     {
         this.metadata.put(key, value);
         return this;
     }
 
     @Override
-    public Context<P> copyFrom(Context<P> other)
+    public Context copyFrom(Context other)
     {
         for (String key : other.keys())
             this.set(key, other.get(key).orElse(null));

--- a/src/main/java/tech/illuin/pipeline/execution/error/PipelineErrorHandler.java
+++ b/src/main/java/tech/illuin/pipeline/execution/error/PipelineErrorHandler.java
@@ -4,14 +4,14 @@ import tech.illuin.pipeline.PipelineException;
 import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.output.Output;
 
-public interface PipelineErrorHandler<P>
+public interface PipelineErrorHandler
 {
-    Output<P> handle(Exception exception, Output<P> previous, Object input, Context<P> context) throws PipelineException;
+    Output handle(Exception exception, Output previous, Object input, Context context) throws PipelineException;
 
     @SuppressWarnings("IllegalCatch")
-    default PipelineErrorHandler<P> andThen(PipelineErrorHandler<P> nextErrorHandler)
+    default PipelineErrorHandler andThen(PipelineErrorHandler nextErrorHandler)
     {
-        return (Exception ex, Output<P> previous, Object input, Context<P> context) -> {
+        return (Exception ex, Output previous, Object input, Context context) -> {
             try {
                 return this.handle(ex, previous, input, context);
             }
@@ -21,7 +21,7 @@ public interface PipelineErrorHandler<P>
         };
     }
 
-    static <P> Output<P> wrapChecked(Exception ex, Output<P> previous, Object input, Context<P> context) throws PipelineException
+    static  Output wrapChecked(Exception ex, Output previous, Object input, Context context) throws PipelineException
     {
         if (ex instanceof RuntimeException re)
             throw re;

--- a/src/main/java/tech/illuin/pipeline/execution/phase/PipelinePhase.java
+++ b/src/main/java/tech/illuin/pipeline/execution/phase/PipelinePhase.java
@@ -7,9 +7,9 @@ import tech.illuin.pipeline.output.Output;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface PipelinePhase<I, P> extends AutoCloseable
+public interface PipelinePhase<I> extends AutoCloseable
 {
-    PipelineStrategy run(I input, Output<P> output, Context<P> context, MetricTags tags) throws Exception;
+    PipelineStrategy run(I input, Output output, Context context, MetricTags tags) throws Exception;
 
     default void close() throws Exception {}
 }

--- a/src/main/java/tech/illuin/pipeline/execution/wrapper/CircuitBreakerWrapper.java
+++ b/src/main/java/tech/illuin/pipeline/execution/wrapper/CircuitBreakerWrapper.java
@@ -15,7 +15,7 @@ import tech.illuin.pipeline.step.execution.wrapper.circuitbreaker.CircuitBreaker
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class CircuitBreakerWrapper<T extends Indexable, I, P> implements StepWrapper<T, I, P>, SinkWrapper<P>
+public class CircuitBreakerWrapper<T extends Indexable, I> implements StepWrapper<T, I>, SinkWrapper
 {
     private final CircuitBreaker circuitBreaker;
 
@@ -25,14 +25,14 @@ public class CircuitBreakerWrapper<T extends Indexable, I, P> implements StepWra
     }
 
     @Override
-    public Step<T, I, P> wrap(Step<T, I, P> step)
+    public Step<T, I> wrap(Step<T, I> step)
     {
         return new CircuitBreakerStep<>(step, this.circuitBreaker);
     }
 
     @Override
-    public Sink<P> wrap(Sink<P> sink)
+    public Sink wrap(Sink sink)
     {
-        return new CircuitBreakerSink<>(sink, this.circuitBreaker);
+        return new CircuitBreakerSink(sink, this.circuitBreaker);
     }
 }

--- a/src/main/java/tech/illuin/pipeline/execution/wrapper/RetryWrapper.java
+++ b/src/main/java/tech/illuin/pipeline/execution/wrapper/RetryWrapper.java
@@ -15,7 +15,7 @@ import tech.illuin.pipeline.step.execution.wrapper.retry.RetryStep;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class RetryWrapper<T extends Indexable, I, P> implements StepWrapper<T, I, P>, SinkWrapper<P>
+public class RetryWrapper<T extends Indexable, I> implements StepWrapper<T, I>, SinkWrapper
 {
     private final Retry retry;
 
@@ -25,14 +25,14 @@ public class RetryWrapper<T extends Indexable, I, P> implements StepWrapper<T, I
     }
 
     @Override
-    public Step<T, I, P> wrap(Step<T, I, P> step)
+    public Step<T, I> wrap(Step<T, I> step)
     {
         return new RetryStep<>(step, this.retry);
     }
 
     @Override
-    public Sink<P> wrap(Sink<P> sink)
+    public Sink wrap(Sink sink)
     {
-        return new RetrySink<>(sink, this.retry);
+        return new RetrySink(sink, this.retry);
     }
 }

--- a/src/main/java/tech/illuin/pipeline/execution/wrapper/TimeLimiterWrapper.java
+++ b/src/main/java/tech/illuin/pipeline/execution/wrapper/TimeLimiterWrapper.java
@@ -18,7 +18,7 @@ import java.util.concurrent.ForkJoinPool;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class TimeLimiterWrapper<T extends Indexable, I, P> implements StepWrapper<T, I, P>, SinkWrapper<P>
+public class TimeLimiterWrapper<T extends Indexable, I> implements StepWrapper<T, I>, SinkWrapper
 {
     private final TimeLimiter limiter;
     private final ExecutorService executor;
@@ -35,14 +35,14 @@ public class TimeLimiterWrapper<T extends Indexable, I, P> implements StepWrappe
     }
 
     @Override
-    public Step<T, I, P> wrap(Step<T, I, P> step)
+    public Step<T, I> wrap(Step<T, I> step)
     {
         return new TimeLimiterStep<>(step, this.limiter, this.executor);
     }
 
     @Override
-    public Sink<P> wrap(Sink<P> sink)
+    public Sink wrap(Sink sink)
     {
-        return new TimeLimiterSink<>(sink, this.limiter, this.executor);
+        return new TimeLimiterSink(sink, this.limiter, this.executor);
     }
 }

--- a/src/main/java/tech/illuin/pipeline/input/author_resolver/AuthorResolver.java
+++ b/src/main/java/tech/illuin/pipeline/input/author_resolver/AuthorResolver.java
@@ -10,9 +10,9 @@ public interface AuthorResolver<T>
 {
     String ANONYMOUS = "anonymous";
 
-    String resolve(T input, Context<?> context);
+    String resolve(T input, Context context);
 
-    static <T> String anonymous(T input, Context<?> context)
+    static <T> String anonymous(T input, Context context)
     {
         return ANONYMOUS;
     }

--- a/src/main/java/tech/illuin/pipeline/input/indexer/SingleAutoIndexer.java
+++ b/src/main/java/tech/illuin/pipeline/input/indexer/SingleAutoIndexer.java
@@ -1,12 +1,10 @@
 package tech.illuin.pipeline.input.indexer;
 
-public class SingleAutoIndexer<T> implements SingleIndexer<T>
+public class SingleAutoIndexer<T extends Indexable> implements SingleIndexer<T>
 {
     @Override
     public Indexable resolve(T payload)
     {
-        if (payload instanceof Indexable indexable)
-            return indexable;
-        throw new IllegalArgumentException("The provided payload of type " + payload.getClass().getName() + " is not Indexable");
+        return payload;
     }
 }

--- a/src/main/java/tech/illuin/pipeline/input/initializer/Initializer.java
+++ b/src/main/java/tech/illuin/pipeline/input/initializer/Initializer.java
@@ -3,26 +3,31 @@ package tech.illuin.pipeline.input.initializer;
 
 import tech.illuin.pipeline.commons.Reflection;
 import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.input.indexer.Indexable;
 import tech.illuin.pipeline.input.initializer.runner.InitializerRunner;
 import tech.illuin.pipeline.input.uid_generator.UIDGenerator;
 import tech.illuin.pipeline.output.Output;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 @FunctionalInterface
-public interface Initializer<I, P>
+public interface Initializer<I>
 {
-    P initialize(I input, Context<P> context, UIDGenerator generator) throws Exception;
+    Object initialize(I input, Context context, UIDGenerator generator) throws Exception;
 
-    static <I, P> P initializeFromParent(I input, Context<P> context)
+    static <I> Object initializeFromParent(I input, Context context)
     {
-        return context.parent().map(Output::payload).orElseThrow(() -> new IllegalArgumentException("The provided context does not reference a parent output"));
+        Optional<Output> parentOutput = context.parent();
+        if (parentOutput.isEmpty())
+            throw new IllegalArgumentException("The provided context does not reference a parent output");
+        return parentOutput.get().payload();
     }
 
-    static <I, P> P initializeFromParentOr(Context<P> context, Supplier<P> or)
+    static <P> Object initializeFromParentOr(Context context, Supplier<P> or)
     {
         return context.parent().map(Output::payload).orElseGet(or);
     }
@@ -36,7 +41,7 @@ public interface Initializer<I, P>
      * Create an {@link Initializer} out of a non-specific instance (i.e. not an {@link Initializer} implementation).
      * The resulting initializer will leverage reflection-based method introspection mechanisms for resolving execution configuration.
      */
-    static <I, P> Initializer<I, P> of(Object target)
+    static <I> Initializer<I> of(Object target)
     {
         return new InitializerRunner<>(target);
     }

--- a/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerAssembler.java
+++ b/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerAssembler.java
@@ -3,11 +3,11 @@ package tech.illuin.pipeline.input.initializer.builder;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface InitializerAssembler<I, P>
+public interface InitializerAssembler<I>
 {
-    void assemble(InitializerBuilder<I, P> builder);
+    void assemble(InitializerBuilder<I> builder);
 
-    default InitializerDescriptor<I, P> build(InitializerBuilder<I, P> builder)
+    default InitializerDescriptor<I> build(InitializerBuilder<I> builder)
     {
         this.assemble(builder);
         return builder.build();

--- a/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerBuilder.java
+++ b/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerBuilder.java
@@ -13,11 +13,11 @@ import java.util.Optional;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class InitializerBuilder<I, P> extends ComponentBuilder<Object, I, P, InitializerDescriptor<I, P>, InitializerConfig>
+public class InitializerBuilder<I> extends ComponentBuilder<Object, I, InitializerDescriptor<I>, InitializerConfig>
 {
     private String id;
-    private Initializer<I, P> initializer;
-    private InitializerErrorHandler<P> errorHandler;
+    private Initializer<I> initializer;
+    private InitializerErrorHandler errorHandler;
 
     public InitializerBuilder()
     {
@@ -25,7 +25,6 @@ public class InitializerBuilder<I, P> extends ComponentBuilder<Object, I, P, Ini
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected void fillFromAnnotation(InitializerConfig annotation)
     {
         try {
@@ -40,49 +39,48 @@ public class InitializerBuilder<I, P> extends ComponentBuilder<Object, I, P, Ini
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected void fillDefaults()
     {
         if (this.id == null)
             this.id = this.initializer.defaultId();
         if (this.errorHandler == null)
-            this.errorHandler = (InitializerErrorHandler<P>) InitializerErrorHandler.RETHROW_ALL;
+            this.errorHandler = InitializerErrorHandler.RETHROW_ALL;
     }
     
-    public InitializerBuilder<I, P> initializer(Initializer<I, P> initializer)
+    public InitializerBuilder<I> initializer(Initializer<I> initializer)
     {
         this.initializer = initializer;
         return this;
     }
 
-    public InitializerBuilder<I, P> initializer(Object target)
+    public InitializerBuilder<I> initializer(Object target)
     {
         this.initializer = Initializer.of(target);
         return this;
     }
 
-    public InitializerBuilder<I, P> withId(String id)
+    public InitializerBuilder<I> withId(String id)
     {
         this.id = id;
         return this;
     }
 
-    public InitializerBuilder<I, P> withErrorHandler(InitializerErrorHandler<P> errorHandler)
+    public InitializerBuilder<I> withErrorHandler(InitializerErrorHandler errorHandler)
     {
         this.errorHandler = errorHandler;
         return this;
     }
 
     @Override
-    protected InitializerDescriptor<I, P> build()
+    protected InitializerDescriptor<I> build()
     {
         if (this.initializer == null)
             throw new IllegalStateException("An InitializerDescriptor cannot be built from a null initializer");
 
         Optional<InitializerConfig> config;
-        if (this.initializer instanceof InitializerRunner<I, P> initializerRunner)
+        if (this.initializer instanceof InitializerRunner<I> initializerRunner)
         {
-            CompiledMethod<InitializerConfig, Object, I, P> compiled = this.compiler.compile(initializerRunner.target());
+            CompiledMethod<InitializerConfig, Object, I> compiled = this.compiler.compile(initializerRunner.target());
             initializerRunner.build(compiled);
             config = Optional.of(compiled.config());
         }

--- a/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerDescriptor.java
+++ b/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerDescriptor.java
@@ -1,6 +1,7 @@
 package tech.illuin.pipeline.input.initializer.builder;
 
 import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.input.indexer.Indexable;
 import tech.illuin.pipeline.input.initializer.Initializer;
 import tech.illuin.pipeline.input.initializer.execution.error.InitializerErrorHandler;
 import tech.illuin.pipeline.input.uid_generator.UIDGenerator;
@@ -8,28 +9,28 @@ import tech.illuin.pipeline.input.uid_generator.UIDGenerator;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public final class InitializerDescriptor<I, P>
+public final class InitializerDescriptor<I>
 {
     private final String id;
-    private final Initializer<I, P> initializer;
-    private final InitializerErrorHandler<P> errorHandler;
+    private final Initializer<I> initializer;
+    private final InitializerErrorHandler errorHandler;
 
     InitializerDescriptor(
         String id,
-        Initializer<I, P> initializer,
-        InitializerErrorHandler<P> errorHandler
+        Initializer<I> initializer,
+        InitializerErrorHandler errorHandler
     ) {
         this.id = id;
         this.initializer = initializer;
         this.errorHandler = errorHandler;
     }
 
-    public P execute(I input, Context<P> ctx, UIDGenerator generator) throws Exception
+    public Object execute(I input, Context ctx, UIDGenerator generator) throws Exception
     {
         return this.initializer.initialize(input, ctx, generator);
     }
 
-    public P handleException(Exception ex, Context<P> ctx, UIDGenerator generator) throws Exception
+    public Object handleException(Exception ex, Context ctx, UIDGenerator generator) throws Exception
     {
         return this.errorHandler.handle(ex, ctx, generator);
     }

--- a/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerMethodArgumentResolver.java
+++ b/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerMethodArgumentResolver.java
@@ -14,9 +14,9 @@ import java.util.stream.Stream;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-class InitializerMethodArgumentResolver<T, I, P> implements MethodArgumentResolver<T, I, P>
+class InitializerMethodArgumentResolver<T, I> implements MethodArgumentResolver<T, I>
 {
-    private final List<MethodArgumentMapperFactory<T, I, P>> factories;
+    private final List<MethodArgumentMapperFactory<T, I>> factories;
 
     private static final Set<Class<?>> LEGAL_ANNOTATIONS = Set.of(
         Input.class, Context.class
@@ -36,7 +36,7 @@ class InitializerMethodArgumentResolver<T, I, P> implements MethodArgumentResolv
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> resolveMapper(Parameter parameter)
+    public MethodArgumentMapper<T, I> resolveMapper(Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         List<Annotation> parameterAnnotations = Stream.of(parameter.getDeclaredAnnotations())

--- a/src/main/java/tech/illuin/pipeline/input/initializer/execution/error/InitializerErrorHandler.java
+++ b/src/main/java/tech/illuin/pipeline/input/initializer/execution/error/InitializerErrorHandler.java
@@ -1,17 +1,18 @@
 package tech.illuin.pipeline.input.initializer.execution.error;
 
 import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.input.indexer.Indexable;
 import tech.illuin.pipeline.input.uid_generator.UIDGenerator;
 
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 @FunctionalInterface
-public interface InitializerErrorHandler<P>
+public interface InitializerErrorHandler
 {
-    P handle(Exception exception, Context<P> context, UIDGenerator generator) throws Exception;
+    Indexable handle(Exception exception, Context context, UIDGenerator generator) throws Exception;
 
-    InitializerErrorHandler<?> RETHROW_ALL = (ex, ctx, gen) -> {
+    InitializerErrorHandler RETHROW_ALL = (ex, ctx, gen) -> {
         throw ex;
     };
 }

--- a/src/main/java/tech/illuin/pipeline/input/initializer/runner/InitializerRunner.java
+++ b/src/main/java/tech/illuin/pipeline/input/initializer/runner/InitializerRunner.java
@@ -8,6 +8,7 @@ import tech.illuin.pipeline.builder.runner_compiler.argument_resolver.method_arg
 import tech.illuin.pipeline.commons.Reflection;
 import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.context.LocalContext;
+import tech.illuin.pipeline.input.indexer.Indexable;
 import tech.illuin.pipeline.input.initializer.Initializer;
 import tech.illuin.pipeline.input.initializer.annotation.InitializerConfig;
 import tech.illuin.pipeline.input.uid_generator.UIDGenerator;
@@ -20,11 +21,11 @@ import java.util.List;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class InitializerRunner<I, P> implements Initializer<I, P>
+public class InitializerRunner<I> implements Initializer<I>
 {
     private final Object target;
     private Method method;
-    private List<MethodArgumentMapper<Object, I, P>> argumentMappers;
+    private List<MethodArgumentMapper<Object, I>> argumentMappers;
 
     private static final Logger logger = LoggerFactory.getLogger(InitializerRunner.class);
 
@@ -36,15 +37,15 @@ public class InitializerRunner<I, P> implements Initializer<I, P>
     }
 
     @Override
-    public P initialize(I input, Context<P> context, UIDGenerator generator) throws Exception
+    public Object initialize(I input, Context context, UIDGenerator generator) throws Exception
     {
-        if (!(context instanceof LocalContext<P> localContext))
+        if (!(context instanceof LocalContext localContext))
             throw new IllegalArgumentException("Invalid context provided to an InitializerRunner instance");
 
         logger.trace("{}#{} launching initializer over target {}#{}", localContext.pipelineTag().pipeline(), localContext.pipelineTag().uid(), this.target.getClass().getName(), Reflection.getMethodSignature(this.method));
 
         try {
-            MethodArguments<Object, I, P> originalArguments = new MethodArguments<>(
+            MethodArguments<Object, I> originalArguments = new MethodArguments<>(
                 null,
                 input,
                 null,
@@ -62,8 +63,7 @@ public class InitializerRunner<I, P> implements Initializer<I, P>
                 .toArray()
             ;
 
-            //noinspection unchecked
-            return (P) this.method.invoke(this.target, arguments);
+            return this.method.invoke(this.target, arguments);
         }
         catch (InvocationTargetException e) {
             if (e.getTargetException() instanceof Exception)
@@ -93,7 +93,7 @@ public class InitializerRunner<I, P> implements Initializer<I, P>
         return this.target;
     }
 
-    public void build(CompiledMethod<InitializerConfig, Object, I, P> compiled)
+    public void build(CompiledMethod<InitializerConfig, Object, I> compiled)
     {
         this.method = compiled.method();
         this.argumentMappers = compiled.mappers();

--- a/src/main/java/tech/illuin/pipeline/metering/tag/TagResolver.java
+++ b/src/main/java/tech/illuin/pipeline/metering/tag/TagResolver.java
@@ -7,5 +7,5 @@ import tech.illuin.pipeline.context.Context;
  */
 public interface TagResolver<T>
 {
-    MetricTags resolve(T input, Context<?> context);
+    MetricTags resolve(T input, Context context);
 }

--- a/src/main/java/tech/illuin/pipeline/output/factory/DefaultOutputFactory.java
+++ b/src/main/java/tech/illuin/pipeline/output/factory/DefaultOutputFactory.java
@@ -1,17 +1,18 @@
 package tech.illuin.pipeline.output.factory;
 
 import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.input.indexer.Indexable;
 import tech.illuin.pipeline.output.Output;
 import tech.illuin.pipeline.output.PipelineTag;
 
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class DefaultOutputFactory<I, P> implements OutputFactory<I, P>
+public class DefaultOutputFactory<I> implements OutputFactory<I>
 {
     @Override
-    public Output<P> create(PipelineTag tag, I input, P payload, Context<P> context)
+    public Output create(PipelineTag tag, I input, Object payload, Context context)
     {
-        return new Output<>(tag, payload, context);
+        return new Output(tag, payload, context);
     }
 }

--- a/src/main/java/tech/illuin/pipeline/output/factory/OutputFactory.java
+++ b/src/main/java/tech/illuin/pipeline/output/factory/OutputFactory.java
@@ -1,13 +1,14 @@
 package tech.illuin.pipeline.output.factory;
 
 import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.input.indexer.Indexable;
 import tech.illuin.pipeline.output.Output;
 import tech.illuin.pipeline.output.PipelineTag;
 
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface OutputFactory<I, P>
+public interface OutputFactory<I>
 {
-    Output<P> create(PipelineTag tag, I input, P payload, Context<P> context);
+    Output create(PipelineTag tag, I input, Object payload, Context context);
 }

--- a/src/main/java/tech/illuin/pipeline/sink/Sink.java
+++ b/src/main/java/tech/illuin/pipeline/sink/Sink.java
@@ -8,9 +8,9 @@ import tech.illuin.pipeline.sink.runner.SinkRunner;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface Sink<T>
+public interface Sink
 {
-    void execute(Output<T> output, Context<T> context) throws Exception;
+    void execute(Output output, Context context) throws Exception;
 
     default String defaultId()
     {
@@ -21,8 +21,8 @@ public interface Sink<T>
      * Create a {@link Sink} out of a non-specific instance (i.e. not a {@link Sink} implementation).
      * The resulting sink will leverage reflection-based method introspection mechanisms for resolving execution configuration.
      */
-    static <T> Sink<T> of(Object target)
+    static Sink of(Object target)
     {
-        return new SinkRunner<>(target);
+        return new SinkRunner(target);
     }
 }

--- a/src/main/java/tech/illuin/pipeline/sink/builder/SinkAssembler.java
+++ b/src/main/java/tech/illuin/pipeline/sink/builder/SinkAssembler.java
@@ -3,11 +3,11 @@ package tech.illuin.pipeline.sink.builder;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface SinkAssembler<P>
+public interface SinkAssembler
 {
-    void assemble(SinkBuilder<P> builder);
+    void assemble(SinkBuilder builder);
 
-    default SinkDescriptor<P> build(SinkBuilder<P> builder)
+    default SinkDescriptor build(SinkBuilder builder)
     {
         this.assemble(builder);
         return builder.build();

--- a/src/main/java/tech/illuin/pipeline/sink/builder/SinkBuilder.java
+++ b/src/main/java/tech/illuin/pipeline/sink/builder/SinkBuilder.java
@@ -14,11 +14,11 @@ import java.util.Optional;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class SinkBuilder<P> extends ComponentBuilder<Object, Object, P, SinkDescriptor<P>, SinkConfig>
+public class SinkBuilder extends ComponentBuilder<Object, Object, SinkDescriptor, SinkConfig>
 {
     private String id;
-    private Sink<P> sink;
-    private SinkWrapper<P> executionWrapper;
+    private Sink sink;
+    private SinkWrapper executionWrapper;
     private SinkErrorHandler errorHandler;
     private Boolean async;
 
@@ -56,52 +56,52 @@ public class SinkBuilder<P> extends ComponentBuilder<Object, Object, P, SinkDesc
             this.errorHandler = SinkErrorHandler.RETHROW_ALL;
     }
     
-    public SinkBuilder<P> sink(Sink<P> sink)
+    public SinkBuilder sink(Sink sink)
     {
         this.sink = sink;
         return this;
     }
 
-    public SinkBuilder<P> sink(Object target)
+    public SinkBuilder sink(Object target)
     {
         this.sink = Sink.of(target);
         return this;
     }
 
-    public SinkBuilder<P> withId(String id)
+    public SinkBuilder withId(String id)
     {
         this.id = id;
         return this;
     }
 
-    public SinkBuilder<P> withWrapper(SinkWrapper<P> wrapper)
+    public SinkBuilder withWrapper(SinkWrapper wrapper)
     {
         this.executionWrapper = wrapper;
         return this;
     }
 
-    public SinkBuilder<P> withErrorHandler(SinkErrorHandler errorHandler)
+    public SinkBuilder withErrorHandler(SinkErrorHandler errorHandler)
     {
         this.errorHandler = errorHandler;
         return this;
     }
 
-    public SinkBuilder<P> setAsync(boolean async)
+    public SinkBuilder setAsync(boolean async)
     {
         this.async = async;
         return this;
     }
 
     @Override
-    protected SinkDescriptor<P> build()
+    protected SinkDescriptor build()
     {
         if (this.sink == null)
             throw new IllegalStateException("A SinkDescriptor cannot be built from a null sink");
 
         Optional<SinkConfig> config;
-        if (this.sink instanceof SinkRunner<P> sinkRunner)
+        if (this.sink instanceof SinkRunner sinkRunner)
         {
-            CompiledMethod<SinkConfig, Object, Object, P> compiled = this.compiler.compile(sinkRunner.target());
+            CompiledMethod<SinkConfig, Object, Object> compiled = this.compiler.compile(sinkRunner.target());
             sinkRunner.build(compiled);
             config = Optional.of(compiled.config());
         }
@@ -112,7 +112,7 @@ public class SinkBuilder<P> extends ComponentBuilder<Object, Object, P, SinkDesc
 
         this.fillDefaults();
 
-        return new SinkDescriptor<>(
+        return new SinkDescriptor(
             this.id,
             this.sink,
             this.async,

--- a/src/main/java/tech/illuin/pipeline/sink/builder/SinkDescriptor.java
+++ b/src/main/java/tech/illuin/pipeline/sink/builder/SinkDescriptor.java
@@ -9,19 +9,19 @@ import tech.illuin.pipeline.sink.execution.wrapper.SinkWrapper;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public final class SinkDescriptor<T>
+public final class SinkDescriptor
 {
     private final String id;
-    private final Sink<T> sink;
+    private final Sink sink;
     private final boolean isAsync;
-    private final SinkWrapper<T> executionWrapper;
+    private final SinkWrapper executionWrapper;
     private final SinkErrorHandler errorHandler;
 
     SinkDescriptor(
         String id,
-        Sink<T> sink,
+        Sink sink,
         boolean isAsync,
-        SinkWrapper<T> executionWrapper,
+        SinkWrapper executionWrapper,
         SinkErrorHandler errorHandler
     ) {
         this.id = id;
@@ -31,18 +31,18 @@ public final class SinkDescriptor<T>
         this.errorHandler = errorHandler;
     }
 
-    public void execute(Output<T> output, Context<T> ctx) throws Exception
+    public void execute(Output output, Context ctx) throws Exception
     {
         this.executionWrapper.wrap(this.sink).execute(output, ctx);
     }
 
-    public void handleException(Exception ex, Output<T> output, Context<T> ctx) throws Exception
+    public void handleException(Exception ex, Output output, Context ctx) throws Exception
     {
         this.errorHandler.handle(ex, output, ctx);
     }
 
     @SuppressWarnings("IllegalCatch")
-    public void handleExceptionThenSwallow(Exception ex, Output<T> output, Context<T> ctx)
+    public void handleExceptionThenSwallow(Exception ex, Output output, Context ctx)
     {
         try {
             this.handleException(ex, output, ctx);

--- a/src/main/java/tech/illuin/pipeline/sink/builder/SinkMethodArgumentResolver.java
+++ b/src/main/java/tech/illuin/pipeline/sink/builder/SinkMethodArgumentResolver.java
@@ -13,9 +13,9 @@ import java.util.stream.Stream;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-class SinkMethodArgumentResolver<T, I, P> implements MethodArgumentResolver<T, I, P>
+class SinkMethodArgumentResolver<T, I, P> implements MethodArgumentResolver<T, I>
 {
-    private final List<MethodArgumentMapperFactory<T, I, P>> factories;
+    private final List<MethodArgumentMapperFactory<T, I>> factories;
 
     private static final Set<Class<?>> LEGAL_ANNOTATIONS = Set.of(
         Input.class, Payload.class, Current.class, Latest.class, Context.class
@@ -40,7 +40,7 @@ class SinkMethodArgumentResolver<T, I, P> implements MethodArgumentResolver<T, I
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> resolveMapper(Parameter parameter)
+    public MethodArgumentMapper<T, I> resolveMapper(Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         List<Annotation> parameterAnnotations = Stream.of(parameter.getDeclaredAnnotations())

--- a/src/main/java/tech/illuin/pipeline/sink/execution/error/SinkErrorHandler.java
+++ b/src/main/java/tech/illuin/pipeline/sink/execution/error/SinkErrorHandler.java
@@ -9,16 +9,16 @@ import tech.illuin.pipeline.output.Output;
 @FunctionalInterface
 public interface SinkErrorHandler
 {
-    void handle(Exception exception, Output<?> output, Context<?> context) throws Exception;
+    void handle(Exception exception, Output output, Context context) throws Exception;
 
-    SinkErrorHandler RETHROW_ALL = (Exception ex, Output<?> output, Context<?> ctx) -> {
+    SinkErrorHandler RETHROW_ALL = (Exception ex, Output output, Context ctx) -> {
         throw ex;
     };
 
     @SuppressWarnings("IllegalCatch")
     default SinkErrorHandler andThen(SinkErrorHandler nextErrorHandler)
     {
-        return (Exception exception, Output<?> output, Context<?> context) -> {
+        return (Exception exception, Output output, Context context) -> {
             try {
                 handle(exception, output, context);
             }

--- a/src/main/java/tech/illuin/pipeline/sink/execution/wrapper/SinkWrapper.java
+++ b/src/main/java/tech/illuin/pipeline/sink/execution/wrapper/SinkWrapper.java
@@ -6,16 +6,16 @@ import tech.illuin.pipeline.sink.Sink;
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 @FunctionalInterface
-public interface SinkWrapper<P>
+public interface SinkWrapper
 {
-    Sink<P> wrap(Sink<P> sink);
+    Sink wrap(Sink sink);
 
-    static <P> Sink<P> noOp(Sink<P> sink)
+    static Sink noOp(Sink sink)
     {
         return sink;
     }
 
-    default SinkWrapper<P> andThen(SinkWrapper<P> nextWrapper)
+    default SinkWrapper andThen(SinkWrapper nextWrapper)
     {
         return step -> nextWrapper.wrap(this.wrap(step));
     }

--- a/src/main/java/tech/illuin/pipeline/sink/execution/wrapper/circuitbreaker/CircuitBreakerSink.java
+++ b/src/main/java/tech/illuin/pipeline/sink/execution/wrapper/circuitbreaker/CircuitBreakerSink.java
@@ -10,12 +10,12 @@ import tech.illuin.pipeline.sink.execution.wrapper.SinkWrapperException;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class CircuitBreakerSink<P> implements Sink<P>
+public class CircuitBreakerSink implements Sink
 {
-    private final Sink<P> sink;
+    private final Sink sink;
     private final CircuitBreaker circuitBreaker;
 
-    public CircuitBreakerSink(Sink<P> sink, CircuitBreaker circuitBreaker)
+    public CircuitBreakerSink(Sink sink, CircuitBreaker circuitBreaker)
     {
         this.sink = sink;
         this.circuitBreaker = circuitBreaker;
@@ -23,7 +23,7 @@ public class CircuitBreakerSink<P> implements Sink<P>
 
     @Override
     @SuppressWarnings("IllegalCatch")
-    public void execute(Output<P> output, Context<P> context) throws Exception
+    public void execute(Output output, Context context) throws Exception
     {
         try {
             this.circuitBreaker.executeCallable(() -> executeSink(output, context));
@@ -37,7 +37,7 @@ public class CircuitBreakerSink<P> implements Sink<P>
     }
 
     @SuppressWarnings("IllegalCatch")
-    private boolean executeSink(Output<P> output, Context<P> context) throws SinkWrapperException
+    private boolean executeSink(Output output, Context context) throws SinkWrapperException
     {
         try {
             this.sink.execute(output, context);

--- a/src/main/java/tech/illuin/pipeline/sink/execution/wrapper/retry/RetrySink.java
+++ b/src/main/java/tech/illuin/pipeline/sink/execution/wrapper/retry/RetrySink.java
@@ -10,12 +10,12 @@ import tech.illuin.pipeline.sink.execution.wrapper.SinkWrapperException;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class RetrySink<P> implements Sink<P>
+public class RetrySink implements Sink
 {
-    private final Sink<P> sink;
+    private final Sink sink;
     private final Retry retry;
 
-    public RetrySink(Sink<P> sink, Retry retry)
+    public RetrySink(Sink sink, Retry retry)
     {
         this.sink = sink;
         this.retry = retry;
@@ -23,7 +23,7 @@ public class RetrySink<P> implements Sink<P>
 
     @Override
     @SuppressWarnings("IllegalCatch")
-    public void execute(Output<P> output, Context<P> context) throws Exception
+    public void execute(Output output, Context context) throws Exception
     {
         try {
             this.retry.executeCallable(() -> executeSink(output, context));
@@ -37,7 +37,7 @@ public class RetrySink<P> implements Sink<P>
     }
 
     @SuppressWarnings("IllegalCatch")
-    private boolean executeSink(Output<P> output, Context<P> context) throws SinkWrapperException
+    private boolean executeSink(Output output, Context context) throws SinkWrapperException
     {
         try {
             this.sink.execute(output, context);

--- a/src/main/java/tech/illuin/pipeline/sink/execution/wrapper/timelimiter/TimeLimiterSink.java
+++ b/src/main/java/tech/illuin/pipeline/sink/execution/wrapper/timelimiter/TimeLimiterSink.java
@@ -12,13 +12,13 @@ import java.util.concurrent.ExecutorService;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class TimeLimiterSink<T extends Indexable, I, P> implements Sink<P>
+public class TimeLimiterSink implements Sink
 {
-    private final Sink<P> sink;
+    private final Sink sink;
     private final TimeLimiter limiter;
     private final ExecutorService executor;
 
-    public TimeLimiterSink(Sink<P> sink, TimeLimiter limiter, ExecutorService executor)
+    public TimeLimiterSink(Sink sink, TimeLimiter limiter, ExecutorService executor)
     {
         this.sink = sink;
         this.limiter = limiter;
@@ -27,7 +27,7 @@ public class TimeLimiterSink<T extends Indexable, I, P> implements Sink<P>
 
     @Override
     @SuppressWarnings("IllegalCatch")
-    public void execute(Output<P> output, Context<P> context) throws Exception
+    public void execute(Output output, Context context) throws Exception
     {
         try {
             this.limiter.executeFutureSupplier(() -> this.executor.submit(() -> this.executeSink(output, context)));
@@ -42,7 +42,7 @@ public class TimeLimiterSink<T extends Indexable, I, P> implements Sink<P>
     }
 
     @SuppressWarnings("IllegalCatch")
-    private void executeSink(Output<P> output, Context<P> context) throws TimeLimiterSinkException
+    private void executeSink(Output output, Context context) throws TimeLimiterSinkException
     {
         try {
             this.sink.execute(output, context);

--- a/src/main/java/tech/illuin/pipeline/sink/runner/SinkRunner.java
+++ b/src/main/java/tech/illuin/pipeline/sink/runner/SinkRunner.java
@@ -20,11 +20,11 @@ import java.util.List;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class SinkRunner<P> implements Sink<P>
+public class SinkRunner implements Sink
 {
     private final Object target;
     private Method method;
-    private List<MethodArgumentMapper<Object, Object, P>> argumentMappers;
+    private List<MethodArgumentMapper<Object, Object>> argumentMappers;
 
     private static final Logger logger = LoggerFactory.getLogger(SinkRunner.class);
 
@@ -36,15 +36,15 @@ public class SinkRunner<P> implements Sink<P>
     }
 
     @Override
-    public void execute(Output<P> output, Context<P> context) throws Exception
+    public void execute(Output output, Context context) throws Exception
     {
-        if (!(context instanceof LocalContext<P> localContext))
+        if (!(context instanceof LocalContext localContext))
             throw new IllegalArgumentException("Invalid context provided to a SinkRunner instance");
 
         logger.trace("{}#{} launching sink over target {}#{}", localContext.pipelineTag().pipeline(), localContext.pipelineTag().uid(), this.target.getClass().getName(), Reflection.getMethodSignature(this.method));
 
         try {
-            MethodArguments<Object, Object, P> originalArguments = new MethodArguments<>(
+            MethodArguments<Object, Object> originalArguments = new MethodArguments<>(
                 null,
                 localContext.input(),
                 output.payload(),
@@ -91,7 +91,7 @@ public class SinkRunner<P> implements Sink<P>
         return this.target;
     }
 
-    public void build(CompiledMethod<SinkConfig, Object, Object, P> compiled)
+    public void build(CompiledMethod<SinkConfig, Object, Object> compiled)
     {
         this.method = compiled.method();
         this.argumentMappers = compiled.mappers();

--- a/src/main/java/tech/illuin/pipeline/step/Step.java
+++ b/src/main/java/tech/illuin/pipeline/step/Step.java
@@ -11,13 +11,13 @@ import tech.illuin.pipeline.step.runner.StepRunner;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface Step<T extends Indexable, I, P>
+public interface Step<T extends Indexable, I>
 {
-    Result execute(T object, I input, P payload, ResultView results, Context<P> context) throws Exception;
+    Result execute(T object, I input, Object payload, ResultView results, Context context) throws Exception;
 
-    default Result execute(T object, I input, Output<P> output, Context<P> context) throws Exception
+    default Result execute(T object, I input, Output output, Context context) throws Exception
     {
-        return this.execute(object, input, output.payload(), output.results().view(object), context);
+        return this.execute(object, input, output.payload(Object.class), output.results().view(object), context);
     }
 
     default String defaultId()
@@ -29,7 +29,7 @@ public interface Step<T extends Indexable, I, P>
      * Create a {@link Step} out of a non-specific instance (i.e. not a {@link Step} implementation).
      * The resulting step will leverage reflection-based method introspection mechanisms for resolving execution configuration.
      */
-    static <T extends Indexable, I, P> Step<T, I, P> of(Object target)
+    static <T extends Indexable, I> Step<T, I> of(Object target)
     {
         return new StepRunner<>(target);
     }

--- a/src/main/java/tech/illuin/pipeline/step/builder/StepAssembler.java
+++ b/src/main/java/tech/illuin/pipeline/step/builder/StepAssembler.java
@@ -5,11 +5,11 @@ import tech.illuin.pipeline.input.indexer.Indexable;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public interface StepAssembler<T extends Indexable, I, P>
+public interface StepAssembler<T extends Indexable, I>
 {
-    void assemble(StepBuilder<T, I, P> builder);
+    void assemble(StepBuilder<T, I> builder);
 
-    default StepDescriptor<T, I, P> build(StepBuilder<T, I, P> builder)
+    default StepDescriptor<T, I> build(StepBuilder<T, I> builder)
     {
         this.assemble(builder);
         return builder.build();

--- a/src/main/java/tech/illuin/pipeline/step/builder/StepBuilder.java
+++ b/src/main/java/tech/illuin/pipeline/step/builder/StepBuilder.java
@@ -21,12 +21,12 @@ import java.util.Optional;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class StepBuilder<T extends Indexable, I, P> extends ComponentBuilder<T, I, P, StepDescriptor<T, I, P>, StepConfig>
+public class StepBuilder<T extends Indexable, I> extends ComponentBuilder<T, I, StepDescriptor<T, I>, StepConfig>
 {
     private String id;
-    private Step<T, I, P> step;
+    private Step<T, I> step;
     private Boolean pinned;
-    private StepWrapper<T, I, P> executionWrapper;
+    private StepWrapper<T, I> executionWrapper;
     private StepCondition executionCondition;
     private ResultEvaluator resultEvaluator;
     private StepErrorHandler errorHandler;
@@ -79,95 +79,95 @@ public class StepBuilder<T extends Indexable, I, P> extends ComponentBuilder<T, 
     }
 
     @SuppressWarnings("unchecked")
-    public StepBuilder<T, I, P> step(Step<? extends T, I, P> step)
+    public StepBuilder<T, I> step(Step<? extends T, I> step)
     {
-        this.step = (Step<T, I, P>) step;
+        this.step = (Step<T, I>) step;
         return this;
     }
 
     @SuppressWarnings("unchecked")
-    public StepBuilder<T, I, P> step(IndexableStep<? extends T> step)
+    public StepBuilder<T, I> step(IndexableStep<? extends T> step)
     {
-        this.step = (Step<T, I, P>) step;
+        this.step = (Step<T, I>) step;
         return this;
     }
 
     @SuppressWarnings("unchecked")
-    public StepBuilder<T, I, P> step(InputStep<I> step)
+    public StepBuilder<T, I> step(InputStep<I> step)
     {
-        this.step = (Step<T, I, P>) step;
+        this.step = (Step<T, I>) step;
         return this;
     }
 
     @SuppressWarnings("unchecked")
-    public StepBuilder<T, I, P> step(PayloadStep<P> step)
+    public StepBuilder<T, I> step(PayloadStep step)
     {
-        this.step = (Step<T, I, P>) step;
+        this.step = (Step<T, I>) step;
         return this;
     }
 
-    public StepBuilder<T, I, P> step(Object target)
+    public StepBuilder<T, I> step(Object target)
     {
-        if (target instanceof PipelineStep<?, ?> pipelineStep)
+        if (target instanceof PipelineStep<?> pipelineStep)
             //noinspection unchecked
-            this.step = (Step<T, I, P>) pipelineStep;
+            this.step = (Step<T, I>) pipelineStep;
         else
             this.step = Step.of(target);
         return this;
     }
 
-    public StepBuilder<T, I, P> withId(String id)
+    public StepBuilder<T, I> withId(String id)
     {
         this.id = id;
         return this;
     }
 
-    public StepBuilder<T, I, P> withWrapper(StepWrapper<T, I, P> wrapper)
+    public StepBuilder<T, I> withWrapper(StepWrapper<T, I> wrapper)
     {
         this.executionWrapper = wrapper;
         return this;
     }
 
-    public StepBuilder<T, I, P> withCondition(Class<? extends Indexable> typeCondition)
+    public StepBuilder<T, I> withCondition(Class<? extends Indexable> typeCondition)
     {
         this.executionCondition = (idx, ctx) -> typeCondition.isInstance(idx);
         return this;
     }
 
-    public StepBuilder<T, I, P> withCondition(StepCondition predicate)
+    public StepBuilder<T, I> withCondition(StepCondition predicate)
     {
         this.executionCondition = predicate;
         return this;
     }
 
-    public StepBuilder<T, I, P> withEvaluation(ResultEvaluator evaluator)
+    public StepBuilder<T, I> withEvaluation(ResultEvaluator evaluator)
     {
         this.resultEvaluator = evaluator;
         return this;
     }
 
-    public StepBuilder<T, I, P> withErrorHandler(StepErrorHandler errorHandler)
+    public StepBuilder<T, I> withErrorHandler(StepErrorHandler errorHandler)
     {
         this.errorHandler = errorHandler;
         return this;
     }
 
-    public StepBuilder<T, I, P> setPinned(boolean pin)
+    public StepBuilder<T, I> setPinned(boolean pin)
     {
         this.pinned = pin;
         return this;
     }
 
     @Override
-    protected StepDescriptor<T, I, P> build()
+    protected StepDescriptor<T, I> build()
     {
         if (this.step == null)
             throw new IllegalStateException("A StepDescriptor cannot be built from a null step");
 
         Optional<StepConfig> config;
-        if (this.step instanceof StepRunner<T, I, P> stepRunner)
+        if (this.step instanceof StepRunner<T, I> stepRunner)
         {
-            CompiledMethod<StepConfig, T, I, P> compiled = this.compiler.compile(stepRunner.target());
+            CompiledMethod<StepConfig, T, I> compiled = this.compiler.compile(stepRunner.target());
             stepRunner.build(compiled);
             config = Optional.of(compiled.config());
         }

--- a/src/main/java/tech/illuin/pipeline/step/builder/StepDescriptor.java
+++ b/src/main/java/tech/illuin/pipeline/step/builder/StepDescriptor.java
@@ -15,21 +15,21 @@ import tech.illuin.pipeline.step.result.Results;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public final class StepDescriptor<T extends Indexable, I, P>
+public final class StepDescriptor<T extends Indexable, I>
 {
     private final String id;
-    private final Step<T, I, P> step;
+    private final Step<T, I> step;
     private final boolean pinned;
-    private final StepWrapper<T, I, P> executionWrapper;
+    private final StepWrapper<T, I> executionWrapper;
     private final StepCondition activationPredicate;
     private final ResultEvaluator resultEvaluator;
     private final StepErrorHandler errorHandler;
 
     StepDescriptor(
         String id,
-        Step<T, I, P> step,
+        Step<T, I> step,
         boolean pinned,
-        StepWrapper<T, I, P> executionWrapper,
+        StepWrapper<T, I> executionWrapper,
         StepCondition activationPredicate,
         ResultEvaluator resultEvaluator,
         StepErrorHandler errorHandler
@@ -43,22 +43,22 @@ public final class StepDescriptor<T extends Indexable, I, P>
         this.errorHandler = errorHandler;
     }
 
-    public Result execute(T data, I input, Output<P> output, Context<P> ctx) throws Exception
+    public Result execute(T data, I input, Output output, Context ctx) throws Exception
     {
         return this.executionWrapper.wrap(this.step).execute(data, input, output, ctx);
     }
 
-    public boolean canExecute(Indexable indexable, Context<P> ctx)
+    public boolean canExecute(Indexable indexable, Context ctx)
     {
         return this.activationPredicate.canExecute(indexable, ctx);
     }
 
-    public StepStrategy postEvaluation(Result result, Indexable object, I input, Context<P> ctx)
+    public StepStrategy postEvaluation(Result result, Indexable object, I input, Context ctx)
     {
         return this.resultEvaluator.evaluate(result, object, input, ctx);
     }
 
-    public Result handleException(Exception ex, I input, P payload, Results results, Context<P> ctx) throws Exception
+    public Result handleException(Exception ex, I input, Object payload, Results results, Context ctx) throws Exception
     {
         return this.errorHandler.handle(ex, input, payload, results, ctx);
     }

--- a/src/main/java/tech/illuin/pipeline/step/builder/StepMethodArgumentResolver.java
+++ b/src/main/java/tech/illuin/pipeline/step/builder/StepMethodArgumentResolver.java
@@ -12,9 +12,9 @@ import java.util.stream.Stream;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class StepMethodArgumentResolver<T, I, P> implements MethodArgumentResolver<T, I, P>
+public class StepMethodArgumentResolver<T, I, P> implements MethodArgumentResolver<T, I>
 {
-    private final List<MethodArgumentMapperFactory<T, I, P>> factories;
+    private final List<MethodArgumentMapperFactory<T, I>> factories;
 
     private static final Set<Class<?>> LEGAL_ANNOTATIONS = ANNOTATIONS;
 
@@ -38,7 +38,7 @@ public class StepMethodArgumentResolver<T, I, P> implements MethodArgumentResolv
     }
 
     @Override
-    public MethodArgumentMapper<T, I, P> resolveMapper(Parameter parameter)
+    public MethodArgumentMapper<T, I> resolveMapper(Parameter parameter)
     {
         Class<?> parameterType = parameter.getType();
         List<Annotation> parameterAnnotations = Stream.of(parameter.getDeclaredAnnotations())

--- a/src/main/java/tech/illuin/pipeline/step/execution/condition/MetadataCondition.java
+++ b/src/main/java/tech/illuin/pipeline/step/execution/condition/MetadataCondition.java
@@ -25,7 +25,7 @@ public class MetadataCondition implements StepCondition
     }
 
     @Override
-    public boolean canExecute(Indexable indexable, Context<?> context)
+    public boolean canExecute(Indexable indexable, Context context)
     {
         for (Map.Entry<String, Object> entry : this.conditions.entrySet())
         {

--- a/src/main/java/tech/illuin/pipeline/step/execution/condition/StepCondition.java
+++ b/src/main/java/tech/illuin/pipeline/step/execution/condition/StepCondition.java
@@ -8,19 +8,19 @@ import tech.illuin.pipeline.input.indexer.Indexable;
  */
 public interface StepCondition
 {
-    boolean canExecute(Indexable indexable, Context<?> context);
+    boolean canExecute(Indexable indexable, Context context);
 
     StepCondition ALWAYS_TRUE = StepCondition::alwaysTrue;
     StepCondition ALWAYS_FALSE = StepCondition::alwaysFalse;
 
     /* Default implementations */
 
-    private static boolean alwaysTrue(Indexable indexable, Context<?> context)
+    private static boolean alwaysTrue(Indexable indexable, Context context)
     {
         return true;
     }
 
-    private static boolean alwaysFalse(Indexable indexable, Context<?> context)
+    private static boolean alwaysFalse(Indexable indexable, Context context)
     {
         return false;
     }

--- a/src/main/java/tech/illuin/pipeline/step/execution/error/StepErrorHandler.java
+++ b/src/main/java/tech/illuin/pipeline/step/execution/error/StepErrorHandler.java
@@ -10,16 +10,16 @@ import tech.illuin.pipeline.step.result.Results;
 @FunctionalInterface
 public interface StepErrorHandler
 {
-    Result handle(Exception exception, Object input, Object payload, Results results, Context<?> context) throws Exception;
+    Result handle(Exception exception, Object input, Object payload, Results results, Context context) throws Exception;
 
-    StepErrorHandler RETHROW_ALL = (Exception ex, Object input, Object payload, Results results, Context<?> ctx) -> {
+    StepErrorHandler RETHROW_ALL = (Exception ex, Object input, Object payload, Results results, Context ctx) -> {
         throw ex;
     };
 
     @SuppressWarnings("IllegalCatch")
     default StepErrorHandler andThen(StepErrorHandler nextErrorHandler)
     {
-        return (Exception exception, Object input, Object payload, Results results, Context<?> context) -> {
+        return (Exception exception, Object input, Object payload, Results results, Context context) -> {
             try {
                 return this.handle(exception, input, payload, results, context);
             }

--- a/src/main/java/tech/illuin/pipeline/step/execution/evaluator/ResultEvaluator.java
+++ b/src/main/java/tech/illuin/pipeline/step/execution/evaluator/ResultEvaluator.java
@@ -9,7 +9,7 @@ import tech.illuin.pipeline.step.result.Result;
  */
 public interface ResultEvaluator
 {
-    StepStrategy evaluate(Result result, Indexable object, Object input, Context<?> ctx);
+    StepStrategy evaluate(Result result, Indexable object, Object input, Context ctx);
 
     ResultEvaluator ALWAYS_CONTINUE = ResultEvaluator::alwaysContinue;
     ResultEvaluator ALWAYS_SKIP = ResultEvaluator::alwaysSkip;
@@ -17,27 +17,27 @@ public interface ResultEvaluator
     ResultEvaluator ALWAYS_STOP = ResultEvaluator::alwaysStop;
     ResultEvaluator ALWAYS_DISCARD = ResultEvaluator::alwaysDiscard;
 
-    private static StepStrategy alwaysContinue(Result result, Indexable object, Object input, Context<?> ctx)
+    private static StepStrategy alwaysContinue(Result result, Indexable object, Object input, Context ctx)
     {
         return StepStrategy.CONTINUE;
     }
 
-    private static StepStrategy alwaysSkip(Result result, Indexable object, Object input, Context<?> ctx)
+    private static StepStrategy alwaysSkip(Result result, Indexable object, Object input, Context ctx)
     {
         return StepStrategy.SKIP;
     }
 
-    private static StepStrategy alwaysAbort(Result result, Indexable object, Object input, Context<?> ctx)
+    private static StepStrategy alwaysAbort(Result result, Indexable object, Object input, Context ctx)
     {
         return StepStrategy.ABORT;
     }
 
-    private static StepStrategy alwaysStop(Result result, Indexable object, Object input, Context<?> ctx)
+    private static StepStrategy alwaysStop(Result result, Indexable object, Object input, Context ctx)
     {
         return StepStrategy.STOP;
     }
 
-    private static StepStrategy alwaysDiscard(Result result, Indexable object, Object input, Context<?> ctx)
+    private static StepStrategy alwaysDiscard(Result result, Indexable object, Object input, Context ctx)
     {
         return StepStrategy.DISCARD_AND_CONTINUE;
     }

--- a/src/main/java/tech/illuin/pipeline/step/execution/wrapper/StepWrapper.java
+++ b/src/main/java/tech/illuin/pipeline/step/execution/wrapper/StepWrapper.java
@@ -7,16 +7,16 @@ import tech.illuin.pipeline.step.Step;
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 @FunctionalInterface
-public interface StepWrapper<T extends Indexable, I, P>
+public interface StepWrapper<T extends Indexable, I>
 {
-    Step<T, I, P> wrap(Step<T, I, P> step);
+    Step<T, I> wrap(Step<T, I> step);
 
-    static <T extends Indexable, I, P> Step<T, I, P> noOp(Step<T, I, P> step)
+    static <T extends Indexable, I> Step<T, I> noOp(Step<T, I> step)
     {
         return step;
     }
 
-    default StepWrapper<T, I, P> andThen(StepWrapper<T, I, P> nextWrapper)
+    default StepWrapper<T, I> andThen(StepWrapper<T, I> nextWrapper)
     {
         return step -> nextWrapper.wrap(this.wrap(step));
     }

--- a/src/main/java/tech/illuin/pipeline/step/execution/wrapper/circuitbreaker/CircuitBreakerStep.java
+++ b/src/main/java/tech/illuin/pipeline/step/execution/wrapper/circuitbreaker/CircuitBreakerStep.java
@@ -12,12 +12,12 @@ import tech.illuin.pipeline.step.result.ResultView;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class CircuitBreakerStep<T extends Indexable, I, P> implements Step<T, I, P>
+public class CircuitBreakerStep<T extends Indexable, I> implements Step<T, I>
 {
-    private final Step<T, I, P> step;
+    private final Step<T, I> step;
     private final CircuitBreaker circuitBreaker;
 
-    public CircuitBreakerStep(Step<T, I, P> step, CircuitBreaker circuitBreaker)
+    public CircuitBreakerStep(Step<T, I> step, CircuitBreaker circuitBreaker)
     {
         this.step = step;
         this.circuitBreaker = circuitBreaker;
@@ -25,7 +25,7 @@ public class CircuitBreakerStep<T extends Indexable, I, P> implements Step<T, I,
 
     @Override
     @SuppressWarnings("IllegalCatch")
-    public Result execute(T object, I input, P payload, ResultView view, Context<P> context) throws Exception
+    public Result execute(T object, I input, Object payload, ResultView view, Context context) throws Exception
     {
         try {
             return this.circuitBreaker.executeCallable(() -> executeStep(object, input, payload, view, context));
@@ -39,7 +39,7 @@ public class CircuitBreakerStep<T extends Indexable, I, P> implements Step<T, I,
     }
 
     @SuppressWarnings("IllegalCatch")
-    private Result executeStep(T object, I input, P payload, ResultView view, Context<P> context) throws StepWrapperException
+    private Result executeStep(T object, I input, Object payload, ResultView view, Context context) throws StepWrapperException
     {
         try {
             return this.step.execute(object, input, payload, view, context);

--- a/src/main/java/tech/illuin/pipeline/step/execution/wrapper/retry/RetryStep.java
+++ b/src/main/java/tech/illuin/pipeline/step/execution/wrapper/retry/RetryStep.java
@@ -12,12 +12,12 @@ import tech.illuin.pipeline.step.result.ResultView;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class RetryStep<T extends Indexable, I, P> implements Step<T, I, P>
+public class RetryStep<T extends Indexable, I> implements Step<T, I>
 {
-    private final Step<T, I, P> step;
+    private final Step<T, I> step;
     private final Retry retry;
 
-    public RetryStep(Step<T, I, P> step, Retry retry)
+    public RetryStep(Step<T, I> step, Retry retry)
     {
         this.step = step;
         this.retry = retry;
@@ -25,7 +25,7 @@ public class RetryStep<T extends Indexable, I, P> implements Step<T, I, P>
 
     @Override
     @SuppressWarnings("IllegalCatch")
-    public Result execute(T object, I input, P payload, ResultView view, Context<P> context) throws Exception
+    public Result execute(T object, I input, Object payload, ResultView view, Context context) throws Exception
     {
         try {
             return this.retry.executeCallable(() -> executeStep(object, input, payload, view, context));
@@ -39,7 +39,7 @@ public class RetryStep<T extends Indexable, I, P> implements Step<T, I, P>
     }
 
     @SuppressWarnings("IllegalCatch")
-    private Result executeStep(T object, I input, P payload, ResultView view, Context<P> context) throws StepWrapperException
+    private Result executeStep(T object, I input, Object payload, ResultView view, Context context) throws StepWrapperException
     {
         try {
             return this.step.execute(object, input, payload, view, context);

--- a/src/main/java/tech/illuin/pipeline/step/execution/wrapper/timelimiter/TimeLimiterStep.java
+++ b/src/main/java/tech/illuin/pipeline/step/execution/wrapper/timelimiter/TimeLimiterStep.java
@@ -14,13 +14,13 @@ import java.util.concurrent.ExecutorService;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class TimeLimiterStep<T extends Indexable, I, P> implements Step<T, I, P>
+public class TimeLimiterStep<T extends Indexable, I> implements Step<T, I>
 {
-    private final Step<T, I, P> step;
+    private final Step<T, I> step;
     private final TimeLimiter limiter;
     private final ExecutorService executor;
 
-    public TimeLimiterStep(Step<T, I, P> step, TimeLimiter limiter, ExecutorService executor)
+    public TimeLimiterStep(Step<T, I> step, TimeLimiter limiter, ExecutorService executor)
     {
         this.step = step;
         this.limiter = limiter;
@@ -29,7 +29,7 @@ public class TimeLimiterStep<T extends Indexable, I, P> implements Step<T, I, P>
 
     @Override
     @SuppressWarnings("IllegalCatch")
-    public Result execute(T object, I input, P payload, ResultView view, Context<P> context) throws Exception
+    public Result execute(T object, I input, Object payload, ResultView view, Context context) throws Exception
     {
         try {
             return this.limiter.executeFutureSupplier(() -> this.executor.submit(() -> executeStep(object, input, payload, view, context)));
@@ -44,7 +44,7 @@ public class TimeLimiterStep<T extends Indexable, I, P> implements Step<T, I, P>
     }
 
     @SuppressWarnings("IllegalCatch")
-    private Result executeStep(T object, I input, P payload, ResultView view, Context<P> context) throws StepWrapperException
+    private Result executeStep(T object, I input, Object payload, ResultView view, Context context) throws StepWrapperException
     {
         try {
             return this.step.execute(object, input, payload, view, context);

--- a/src/main/java/tech/illuin/pipeline/step/runner/StepRunner.java
+++ b/src/main/java/tech/illuin/pipeline/step/runner/StepRunner.java
@@ -21,11 +21,11 @@ import java.util.List;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class StepRunner<T extends Indexable, I, P> implements Step<T, I, P>
+public class StepRunner<T extends Indexable, I> implements Step<T, I>
 {
     private final java.lang.Object target;
     private Method method;
-    private List<MethodArgumentMapper<T, I, P>> argumentMappers;
+    private List<MethodArgumentMapper<T, I>> argumentMappers;
 
     private static final Logger logger = LoggerFactory.getLogger(StepRunner.class);
 
@@ -37,15 +37,15 @@ public class StepRunner<T extends Indexable, I, P> implements Step<T, I, P>
     }
 
     @Override
-    public Result execute(T object, I input, P payload, ResultView results, Context<P> context) throws Exception
+    public Result execute(T object, I input, Object payload, ResultView results, Context context) throws Exception
     {
-        if (!(context instanceof LocalContext<P> localContext))
+        if (!(context instanceof LocalContext localContext))
             throw new IllegalArgumentException("Invalid context provided to a SinkRunner instance");
 
         logger.trace("{}#{} launching step over target {}#{}", localContext.pipelineTag().pipeline(), localContext.pipelineTag().uid(), this.target.getClass().getName(), Reflection.getMethodSignature(this.method));
 
         try {
-            MethodArguments<T, I, P> originalArguments = new MethodArguments<>(
+            MethodArguments<T, I> originalArguments = new MethodArguments<>(
                 object,
                 input,
                 payload,
@@ -94,7 +94,7 @@ public class StepRunner<T extends Indexable, I, P> implements Step<T, I, P>
         return this.target;
     }
 
-    public void build(CompiledMethod<StepConfig, T, I, P> compiled)
+    public void build(CompiledMethod<StepConfig, T, I> compiled)
     {
         this.method = compiled.method();
         this.argumentMappers = compiled.mappers();

--- a/src/main/java/tech/illuin/pipeline/step/variant/IndexableStep.java
+++ b/src/main/java/tech/illuin/pipeline/step/variant/IndexableStep.java
@@ -11,14 +11,14 @@ import tech.illuin.pipeline.step.result.ResultView;
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 @FunctionalInterface
-public interface IndexableStep<T extends Indexable> extends Step<T, Object, Object>
+public interface IndexableStep<T extends Indexable> extends Step<T, Object>
 {
-    Result execute(T object, ResultView results, Context<?> context) throws Exception;
+    Result execute(T object, ResultView results, Context context) throws Exception;
 
     /**
      * @see #execute(Indexable, ResultView, Context)
      */
-    default Result execute(T object, Object input, Object payload, ResultView results, Context<Object> context) throws Exception
+    default Result execute(T object, Object input, Object payload, ResultView results, Context context) throws Exception
     {
         return this.execute(object, results, context);
     }
@@ -26,7 +26,7 @@ public interface IndexableStep<T extends Indexable> extends Step<T, Object, Obje
     /**
      * @see #execute(Indexable, ResultView, Context)
      */
-    default Result execute(T object, Output<?> output) throws Exception
+    default Result execute(T object, Output output) throws Exception
     {
         return this.execute(object, output.results().view(object), output.context());
     }

--- a/src/main/java/tech/illuin/pipeline/step/variant/InputStep.java
+++ b/src/main/java/tech/illuin/pipeline/step/variant/InputStep.java
@@ -10,11 +10,11 @@ import tech.illuin.pipeline.step.result.ResultView;
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 @FunctionalInterface
-public interface InputStep<I> extends Step<Indexable, I, Object>
+public interface InputStep<I> extends Step<Indexable, I>
 {
-    Result execute(I input, ResultView results, Context<?> context) throws Exception;
+    Result execute(I input, ResultView results, Context context) throws Exception;
 
-    default Result execute(Indexable object, I input, Object payload, ResultView results, Context<Object> context) throws Exception
+    default Result execute(Indexable object, I input, Object payload, ResultView results, Context context) throws Exception
     {
         return this.execute(input, results, context);
     }

--- a/src/main/java/tech/illuin/pipeline/step/variant/PayloadStep.java
+++ b/src/main/java/tech/illuin/pipeline/step/variant/PayloadStep.java
@@ -10,11 +10,11 @@ import tech.illuin.pipeline.step.result.ResultView;
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 @FunctionalInterface
-public interface PayloadStep<P> extends Step<Indexable, Object, P>
+public interface PayloadStep extends Step<Indexable, Object>
 {
-    Result execute(P payload, ResultView results, Context<P> context) throws Exception;
+    Result execute(Object payload, ResultView results, Context context) throws Exception;
 
-    default Result execute(Indexable object, Object input, P payload, ResultView results, Context<P> context) throws Exception
+    default Result execute(Indexable object, Object input, Object payload, ResultView results, Context context) throws Exception
     {
         return this.execute(payload, results, context);
     }

--- a/src/main/java/tech/illuin/pipeline/step/variant/PipelineStep.java
+++ b/src/main/java/tech/illuin/pipeline/step/variant/PipelineStep.java
@@ -18,34 +18,34 @@ import java.util.function.Function;
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 @Experimental
-public final class PipelineStep<I, P> implements Step<Indexable, I, P>
+public final class PipelineStep<I> implements Step<Indexable, I>
 {
-    private final Pipeline<I, P> pipeline;
-    private final Function<Output<P>, Result> resultMapper;
+    private final Pipeline<I> pipeline;
+    private final Function<Output, Result> resultMapper;
 
     public static final String PARENT_PIPELINE = "parent_pipeline";
 
-    public PipelineStep(Pipeline<I, P> pipeline, Function<Output<P>, Result> resultMapper)
+    public PipelineStep(Pipeline<I> pipeline, Function<Output, Result> resultMapper)
     {
         this.pipeline = pipeline;
         this.resultMapper = resultMapper;
     }
 
     @Override
-    public Result execute(Indexable object, I input, P payload, ResultView results, Context<P> context) throws Exception
+    public Result execute(Indexable object, I input, Object payload, ResultView results, Context context) throws Exception
     {
         try {
-            if (!(context instanceof LocalContext<P> localContext))
+            if (!(context instanceof LocalContext localContext))
                 throw new IllegalArgumentException("The provided context is not a LocalContext");
 
             /* TODO: Bad design -> this should be challenged ASAP */
-            Output<P> prev = new Output<>(
+            Output prev = new Output(
                 localContext.pipelineTag(),
                 payload,
                 context
             );
             prev.results().register(results);
-            Output<P> out = this.pipeline.run(input, new SimpleContext<>(prev)
+            Output out = this.pipeline.run(input, new SimpleContext(prev)
                 .copyFrom(context)
                 .set(PARENT_PIPELINE, localContext.pipelineTag())
             );

--- a/src/test/java/tech/illuin/pipeline/PipelineHelperTest.java
+++ b/src/test/java/tech/illuin/pipeline/PipelineHelperTest.java
@@ -12,16 +12,16 @@ public class PipelineHelperTest {
 
     @Test
     public void newContext() {
-        Pipeline pipeline = Pipeline.of("my-test").build();
-        Context<?> context = pipeline.newContext();
+        Pipeline<?> pipeline = Pipeline.of("my-test").build();
+        Context context = pipeline.newContext();
         assertTrue(context.parent().isEmpty());
     }
 
     @Test
     public void newContextWithParent() throws PipelineException {
-        Pipeline pipeline = Pipeline.of("my-test").build();
-        Output<A> output = pipeline.run();
-        Context<A> context = pipeline.newContext(output);
+        Pipeline<?> pipeline = Pipeline.of("my-test").build();
+        Output output = pipeline.run();
+        Context context = pipeline.newContext(output);
         assertEquals(output, context.parent().get());
     }
 }

--- a/src/test/java/tech/illuin/pipeline/context/SimpleContextTest.java
+++ b/src/test/java/tech/illuin/pipeline/context/SimpleContextTest.java
@@ -11,8 +11,8 @@ public class SimpleContextTest
     @Test
     public void copyFrom()
     {
-        Context<Void> contextA = new SimpleContext<Void>().set("a", true).set("b", false);
-        Context<Void> contextB = new SimpleContext<>();
+        Context contextA = new SimpleContext().set("a", true).set("b", false);
+        Context contextB = new SimpleContext();
 
         contextB.copyFrom(contextA);
 
@@ -23,8 +23,8 @@ public class SimpleContextTest
     @Test
     public void copyFrom__shouldCombine()
     {
-        Context<Void> contextA = new SimpleContext<Void>().set("a", true).set("b", false);
-        Context<Void> contextB = new SimpleContext<Void>().set("c", "abcde").set("d", 123);
+        Context contextA = new SimpleContext().set("a", true).set("b", false);
+        Context contextB = new SimpleContext().set("c", "abcde").set("d", 123);
 
         contextB.copyFrom(contextA);
 
@@ -37,8 +37,8 @@ public class SimpleContextTest
     @Test
     public void copyFrom__shouldOverwrite()
     {
-        Context<Void> contextA = new SimpleContext<Void>().set("a", true).set("b", true);
-        Context<Void> contextB = new SimpleContext<Void>().set("a", false);
+        Context contextA = new SimpleContext().set("a", true).set("b", true);
+        Context contextB = new SimpleContext().set("a", false);
 
         contextB.copyFrom(contextA);
 

--- a/src/test/java/tech/illuin/pipeline/execution/error/PipelineErrorHandlerTest.java
+++ b/src/test/java/tech/illuin/pipeline/execution/error/PipelineErrorHandlerTest.java
@@ -21,7 +21,7 @@ public class PipelineErrorHandlerTest
     @Test
     public void shouldWrapChecked()
     {
-        PipelineErrorHandler<Object> handler = PipelineErrorHandler::wrapChecked;
+        PipelineErrorHandler handler = PipelineErrorHandler::wrapChecked;
 
         Assertions.assertThrows(PipelineException.class, () -> handler.handle(new Exception("checked"), null, null, null));
         Assertions.assertThrows(CustomRuntimeException.class, () -> handler.handle(new CustomRuntimeException(), null, null, null));
@@ -30,11 +30,11 @@ public class PipelineErrorHandlerTest
     @Test
     public void shouldWrap()
     {
-        PipelineErrorHandler<Object> handler0 = PipelineErrorHandlerTest::handler0;
-        PipelineErrorHandler<Object> handler1 = PipelineErrorHandlerTest::handler1;
+        PipelineErrorHandler handler0 = PipelineErrorHandlerTest::handler0;
+        PipelineErrorHandler handler1 = PipelineErrorHandlerTest::handler1;
 
         Exception ex = new Exception("test-message");
-        Output<?> out = Assertions.assertDoesNotThrow(() -> handler0.andThen(handler1).handle(ex, null, null, null));
+        Output out = Assertions.assertDoesNotThrow(() -> handler0.andThen(handler1).handle(ex, null, null, null));
 
         Assertions.assertEquals(ex.getMessage(), out.tag().pipeline());
     }
@@ -42,16 +42,16 @@ public class PipelineErrorHandlerTest
     @Test
     public void shouldTransferPreviousState() throws Exception
     {
-        Pipeline<String, VoidPayload> recovery = Pipeline.<String>of("recovery")
+        Pipeline<String> recovery = Pipeline.<String>of("recovery")
             .registerStep((in, res, ctx) -> new TestResult("def", "ko"))
             .build()
         ;
 
-        PipelineErrorHandler<VoidPayload> errorHandler = (exception, previous, input, context) -> recovery.run(
+        PipelineErrorHandler errorHandler = (exception, previous, input, context) -> recovery.run(
             (String) input,
-            new SimpleContext<>(previous).copyFrom(context)
+            new SimpleContext(previous).copyFrom(context)
         );
-        Pipeline<String, ?> pipeline = Pipeline.<String>of("pipeline")
+        Pipeline<String> pipeline = Pipeline.<String>of("pipeline")
             .registerStep((in, res, ctx) -> new TestResult("abc", "ok"))
             .registerStep((in, res, ctx) -> { throw new RuntimeException("Random error"); })
             .setErrorHandler(errorHandler)
@@ -67,18 +67,18 @@ public class PipelineErrorHandlerTest
         recovery.close();
     }
 
-    private static Output<Object> handler0(Exception exception, Output<Object> previous, Object input, Context<?> context) throws PipelineException
+    private static Output handler0(Exception exception, Output previous, Object input, Context context) throws PipelineException
     {
         throw new PipelineException(exception.getMessage(), exception);
     }
 
-    private static Output<Object> handler1(Exception exception, Output<Object> previous, Object input, Context<?> context)
+    private static Output handler1(Exception exception, Output previous, Object input, Context context)
     {
         return new DefaultOutputFactory<>().create(
             new PipelineTag(UUIDGenerator.INSTANCE.generate(), exception.getMessage(), AuthorResolver.ANONYMOUS),
             null,
             null,
-            new SimpleContext<>()
+            new SimpleContext()
         );
     }
 

--- a/src/test/java/tech/illuin/pipeline/execution/phase/PipelinePhaseTest.java
+++ b/src/test/java/tech/illuin/pipeline/execution/phase/PipelinePhaseTest.java
@@ -20,7 +20,7 @@ public class PipelinePhaseTest
     public void testPipeline__continue()
     {
         Counters counters = new Counters();
-        Pipeline<Object, ?> pipeline = createPipeline("test-continue", (res, obj, in, ctx) -> StepStrategy.CONTINUE, counters);
+        Pipeline<Object> pipeline = createPipeline("test-continue", (res, obj, in, ctx) -> StepStrategy.CONTINUE, counters);
 
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -36,7 +36,7 @@ public class PipelinePhaseTest
     public void testPipeline__stop()
     {
         Counters counters = new Counters();
-        Pipeline<Object, ?> pipeline = createPipeline("test-stop", (res, obj, in, ctx) -> StepStrategy.STOP, counters);
+        Pipeline<Object> pipeline = createPipeline("test-stop", (res, obj, in, ctx) -> StepStrategy.STOP, counters);
 
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -52,7 +52,7 @@ public class PipelinePhaseTest
     public void testPipeline__abort()
     {
         Counters counters = new Counters();
-        Pipeline<Object, ?> pipeline = createPipeline("test-abort", (res, obj, in, ctx) -> StepStrategy.ABORT, counters);
+        Pipeline<Object> pipeline = createPipeline("test-abort", (res, obj, in, ctx) -> StepStrategy.ABORT, counters);
 
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -68,7 +68,7 @@ public class PipelinePhaseTest
     public void testPipeline__exit()
     {
         Counters counters = new Counters();
-        Pipeline<Object, ?> pipeline = createPipeline("test-exit", (res, obj, in, ctx) -> StepStrategy.EXIT, counters);
+        Pipeline<Object> pipeline = createPipeline("test-exit", (res, obj, in, ctx) -> StepStrategy.EXIT, counters);
 
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -80,7 +80,7 @@ public class PipelinePhaseTest
         Assertions.assertEquals(0, counters.sink_async.get());
     }
 
-    public static Pipeline<Object, VoidPayload> createPipeline(String name, ResultEvaluator evaluator, Counters counters)
+    public static Pipeline<Object> createPipeline(String name, ResultEvaluator evaluator, Counters counters)
     {
         return Assertions.assertDoesNotThrow(() -> Pipeline.of(name)
             .registerStep(builder -> builder

--- a/src/test/java/tech/illuin/pipeline/generic/TestFactory.java
+++ b/src/test/java/tech/illuin/pipeline/generic/TestFactory.java
@@ -17,7 +17,7 @@ public class TestFactory
 {
     private static final Logger logger = LoggerFactory.getLogger(TestFactory.class);
 
-    public static A initializer(Void input, Context<A> context, UIDGenerator generator)
+    public static A initializer(Void input, Context context, UIDGenerator generator)
     {
         return new A(generator.generate(), List.of(
             new B(generator.generate(), "b1"),
@@ -25,7 +25,7 @@ public class TestFactory
         ));
     }
 
-    public static A initializerOfEmpty(Void input, Context<A> context, UIDGenerator generator)
+    public static A initializerOfEmpty(Void input, Context context, UIDGenerator generator)
     {
         return new A(generator.generate(), Collections.emptyList());
     }

--- a/src/test/java/tech/illuin/pipeline/generic/Tests.java
+++ b/src/test/java/tech/illuin/pipeline/generic/Tests.java
@@ -14,12 +14,12 @@ public final class Tests
 {
     private Tests() {}
 
-    public static List<String> getResultTypes(Output<?> output, Indexable object)
+    public static List<String> getResultTypes(Output output, Indexable object)
     {
         return output.results(object).stream().map(Result::name).sorted().toList();
     }
 
-    public static List<String> getResultTypes(Output<?> output)
+    public static List<String> getResultTypes(Output output)
     {
         return output.results().stream().map(Result::name).sorted().toList();
     }

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/initializer/TestAnnotatedInitializers.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/initializer/TestAnnotatedInitializers.java
@@ -28,7 +28,7 @@ public class TestAnnotatedInitializers
         public ErrorHandler(String name, BiFunction<UIDGenerator, I, P> function) { super(name, function); }
     }
 
-    private abstract static class AnnotatedInitializer<I, P> implements Initializer<I, P>
+    private abstract static class AnnotatedInitializer<I, P> implements Initializer<I>
     {
         private final String name;
         private final BiFunction<UIDGenerator, I, P> function;
@@ -42,7 +42,7 @@ public class TestAnnotatedInitializers
         }
 
         @Override
-        public P initialize(I input, Context<P> context, UIDGenerator generator)
+        public P initialize(I input, Context context, UIDGenerator generator)
         {
             logger.info("test:{}: ~", this.name);
             return this.function.apply(generator, input);

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/initializer/execution/error/WrapAll.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/initializer/execution/error/WrapAll.java
@@ -10,10 +10,10 @@ import java.util.Collections;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class WrapAll implements InitializerErrorHandler<A>
+public class WrapAll implements InitializerErrorHandler
 {
     @Override
-    public A handle(Exception exception, Context<A> context, UIDGenerator generator)
+    public A handle(Exception exception, Context context, UIDGenerator generator)
     {
         return new A(generator.generate(), Collections.emptyList());
     }

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/sink/TestAnnotatedSinks.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/sink/TestAnnotatedSinks.java
@@ -17,27 +17,27 @@ import java.util.function.Consumer;
 public class TestAnnotatedSinks
 {
     @SinkConfig(id = "test-sink-error-handler", errorHandler = WrapAll.class)
-    public static class ErrorHandler<T extends Indexable> extends AnnotatedSink<T>
+    public static class ErrorHandler<T extends Indexable> extends AnnotatedSink
     {
-        public ErrorHandler(String name, Consumer<T> function) { super(name, function); }
+        public ErrorHandler(String name, Consumer<Object> function) { super(name, function); }
         public ErrorHandler(String name) { super(name); }
     }
 
     @SinkConfig(id = "test-sink-async", async = true)
-    public static class Async<T extends Indexable> extends AnnotatedSink<T>
+    public static class Async<T extends Indexable> extends AnnotatedSink
     {
-        public Async(String name, Consumer<T> function) { super(name, function); }
+        public Async(String name, Consumer<Object> function) { super(name, function); }
         public Async(String name) { super(name); }
     }
 
-    private abstract static class AnnotatedSink<P> implements Sink<P>
+    private abstract static class AnnotatedSink implements Sink
     {
         private final String name;
-        private final Consumer<P> function;
+        private final Consumer<Object> function;
 
         private static final Logger logger = LoggerFactory.getLogger(AnnotatedSink.class);
 
-        public AnnotatedSink(String name, Consumer<P> function)
+        public AnnotatedSink(String name, Consumer<Object> function)
         {
             this.name = name;
             this.function = function;
@@ -49,7 +49,7 @@ public class TestAnnotatedSinks
         }
 
         @Override
-        public void execute(Output<P> output, Context<P> context)
+        public void execute(Output output, Context context)
         {
             logger.info("test:{}: ~", this.name);
             this.function.accept(output.payload());

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/sink/execution/error/WrapAll.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/sink/execution/error/WrapAll.java
@@ -14,7 +14,7 @@ public class WrapAll implements SinkErrorHandler
     private static final Logger logger = LoggerFactory.getLogger(WrapAll.class);
 
     @Override
-    public void handle(Exception exception, Output<?> output, Context<?> context)
+    public void handle(Exception exception, Output output, Context context)
     {
         logger.error(exception.getMessage());
     }

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/step/TestAnnotatedSteps.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/step/TestAnnotatedSteps.java
@@ -76,7 +76,7 @@ public class TestAnnotatedSteps
         }
 
         @Override
-        public Result execute(T data, ResultView results, Context<?> context)
+        public Result execute(T data, ResultView results, Context context)
         {
             logger.info("test:{}: {}", this.name, data);
             return new TestResult(this.name, this.function.apply(data));

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/step/TestStep.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/step/TestStep.java
@@ -35,7 +35,7 @@ public class TestStep<T extends Indexable> implements IndexableStep<T>
     }
 
     @Override
-    public Result execute(T data, ResultView results, Context<?> context)
+    public Result execute(T data, ResultView results, Context context)
     {
         logger.info("test:{}: {}", this.name, data);
         return new TestResult(this.name, this.function.apply(data));

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/condition/IsTypeA.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/condition/IsTypeA.java
@@ -11,7 +11,7 @@ import tech.illuin.pipeline.step.execution.condition.StepCondition;
 public class IsTypeA implements StepCondition
 {
     @Override
-    public boolean canExecute(Indexable indexable, Context<?> context)
+    public boolean canExecute(Indexable indexable, Context context)
     {
         return indexable instanceof A;
     }

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/condition/IsTypeB.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/condition/IsTypeB.java
@@ -11,7 +11,7 @@ import tech.illuin.pipeline.step.execution.condition.StepCondition;
 public class IsTypeB implements StepCondition
 {
     @Override
-    public boolean canExecute(Indexable indexable, Context<?> context)
+    public boolean canExecute(Indexable indexable, Context context)
     {
         return indexable instanceof B;
     }

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/error/WrapAll.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/error/WrapAll.java
@@ -12,7 +12,7 @@ import tech.illuin.pipeline.step.result.Results;
 public class WrapAll implements StepErrorHandler
 {
     @Override
-    public Result handle(Exception exception, Object input, Object payload, Results results, Context<?> context)
+    public Result handle(Exception exception, Object input, Object payload, Results results, Context context)
     {
         return new TestResult("error", "ko");
     }

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/evaluator/AbortOnStatusKo.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/evaluator/AbortOnStatusKo.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 public class AbortOnStatusKo implements ResultEvaluator
 {
     @Override
-    public StepStrategy evaluate(Result result, Indexable object, Object input, Context<?> ctx)
+    public StepStrategy evaluate(Result result, Indexable object, Object input, Context ctx)
     {
         return isKo(result) ? StepStrategy.ABORT : StepStrategy.CONTINUE;
     }

--- a/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/evaluator/DiscardOnStatusKo.java
+++ b/src/test/java/tech/illuin/pipeline/generic/pipeline/step/execution/evaluator/DiscardOnStatusKo.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 public class DiscardOnStatusKo implements ResultEvaluator
 {
     @Override
-    public StepStrategy evaluate(Result result, Indexable object, Object input, Context<?> ctx)
+    public StepStrategy evaluate(Result result, Indexable object, Object input, Context ctx)
     {
         return isKo(result) ? StepStrategy.DISCARD_AND_CONTINUE : StepStrategy.CONTINUE;
     }

--- a/src/test/java/tech/illuin/pipeline/input/initializer/AnnotationTest.java
+++ b/src/test/java/tech/illuin/pipeline/input/initializer/AnnotationTest.java
@@ -19,19 +19,19 @@ public class AnnotationTest
     {
         var counter = new AtomicInteger(0);
 
-        Pipeline<Void, ?> pipeline = Assertions.assertDoesNotThrow(() -> AnnotationTest.createAnnotatedPipeline(counter));
+        Pipeline<Void> pipeline = Assertions.assertDoesNotThrow(() -> AnnotationTest.createAnnotatedPipeline(counter));
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(1, counter.get());
     }
 
-    public static Pipeline<Void, A> createAnnotatedPipeline(AtomicInteger counter)
+    public static Pipeline<Void> createAnnotatedPipeline(AtomicInteger counter)
     {
-        Initializer<Void, A> initializer = new TestAnnotatedInitializers.ErrorHandler<>("0", (gen, in) -> new A("a", Collections.emptyList()));
+        Initializer<Void> initializer = new TestAnnotatedInitializers.ErrorHandler<>("0", (gen, in) -> new A("a", Collections.emptyList()));
         return Pipeline.of("test-annotated", initializer)
             .registerSink(((output, context) -> {
-                if (output.payload().uid().equals("a"))
+                if (output.payload(A.class).uid().equals("a"))
                     counter.incrementAndGet();
             }))
             .build()

--- a/src/test/java/tech/illuin/pipeline/input/initializer/InitializerTest.java
+++ b/src/test/java/tech/illuin/pipeline/input/initializer/InitializerTest.java
@@ -19,7 +19,7 @@ public class InitializerTest
     {
         var counter = new AtomicInteger(0);
 
-        Pipeline<String, B> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithInitializer(counter));
+        Pipeline<String> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithInitializer(counter));
         Assertions.assertDoesNotThrow(() -> pipeline.run("my_input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
@@ -31,7 +31,7 @@ public class InitializerTest
     {
         var counter = new AtomicInteger(0);
 
-        Pipeline<String, B> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithInitializer_exception(counter));
+        Pipeline<String> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithInitializer_exception(counter));
         PipelineException ex = Assertions.assertThrows(PipelineException.class, () -> pipeline.run("my_input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
@@ -39,22 +39,22 @@ public class InitializerTest
         Assertions.assertEquals("my_input", ex.getMessage());
     }
 
-    public static Pipeline<String, B> createPipelineWithInitializer(AtomicInteger counter)
+    public static Pipeline<String> createPipelineWithInitializer(AtomicInteger counter)
     {
-        Initializer<String, B> init = (input, context, generator) -> new B(generator.generate(), input);
+        Initializer<String> init = (input, context, generator) -> new B(generator.generate(), input);
         return Pipeline.of("test-init", init)
             .registerIndexer(SingleIndexer.auto())
             .registerSink((o, ctx) -> {
-                if (o.payload().name().equals("my_input"))
+                if (o.payload(B.class).name().equals("my_input"))
                     counter.incrementAndGet();
             })
             .build()
         ;
     }
 
-    public static Pipeline<String, B> createPipelineWithInitializer_exception(AtomicInteger counter)
+    public static Pipeline<String> createPipelineWithInitializer_exception(AtomicInteger counter)
     {
-        Initializer<String, B> init = (input, context, generator) -> { throw new Exception(input); };
+        Initializer<String> init = (input, context, generator) -> { throw new Exception(input); };
         return Pipeline.of("test-init-error", init)
             .registerIndexer(SingleIndexer.auto())
             .registerSink((o, ctx) -> counter.incrementAndGet())

--- a/src/test/java/tech/illuin/pipeline/input/initializer/annotation/PipelineInitializerAnnotationTest.java
+++ b/src/test/java/tech/illuin/pipeline/input/initializer/annotation/PipelineInitializerAnnotationTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import tech.illuin.pipeline.Pipeline;
 import tech.illuin.pipeline.PipelineException;
 import tech.illuin.pipeline.input.indexer.Indexable;
+import tech.illuin.pipeline.input.indexer.Indexer;
+import tech.illuin.pipeline.input.indexer.SingleIndexer;
 import tech.illuin.pipeline.input.initializer.Initializer;
 import tech.illuin.pipeline.input.initializer.annotation.initializer.*;
 import tech.illuin.pipeline.input.initializer.annotation.initializer.InitializerWithException.InitializerWithExceptionException;
@@ -23,41 +25,29 @@ public class PipelineInitializerAnnotationTest
     @Test
     public void testPipeline__shouldCompile_input()
     {
-        Pipeline<Object, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input("test-input"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input("test-input"));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertEquals("input", output.payload().object().value());
+        Assertions.assertEquals("input", output.payload(TestPayload.class).object().value());
     }
 
     @Test
     public void testPipeline__shouldCompile_input_assembler()
     {
-        Pipeline<Object, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_assembler("test-input"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_assembler("test-input"));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertEquals("input", output.payload().object().value());
+        Assertions.assertEquals("input", output.payload(TestPayload.class).object().value());
     }
-
-    @Test
-    public void testPipeline__shouldCompile_input_of()
-    {
-        Pipeline<Object, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_of("test-input"));
-
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
-        Assertions.assertDoesNotThrow(pipeline::close);
-
-        Assertions.assertEquals("input", output.payload().object().value());
-    }
-
 
     @Test
     public void testPipeline__shouldCompile_input_exception()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_exception("test-input"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_exception("test-input"));
 
         PipelineException exception = Assertions.assertThrows(PipelineException.class, () -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -68,14 +58,14 @@ public class PipelineInitializerAnnotationTest
     @Test
     public void testPipeline__shouldCompile_tags()
     {
-        Pipeline<Object, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_tags("test-tags"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_tags("test-tags"));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
             "test-tags#init-with_tags",
-            output.payload().object().value()
+            output.payload(TestPayload.class).object().value()
         );
     }
 
@@ -85,153 +75,135 @@ public class PipelineInitializerAnnotationTest
         String key = "test_key";
         String value = "my_value";
 
-        Pipeline<Object, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_context("test-context", key));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_context("test-context", key));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx.set(key, value)));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx.set(key, value)));
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertEquals(value, output.payload().object().value());
+        Assertions.assertEquals(value, output.payload(TestPayload.class).object().value());
     }
 
     @Test
     public void testPipeline__shouldCompile_contextKey()
     {
-        Pipeline<Object, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKey("test-context-key"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKey("test-context-key"));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx
             .set("some-metadata", "my_value")
         ));
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertEquals("single(my_value)", output.payload().object().value());
+        Assertions.assertEquals("single(my_value)", output.payload(TestPayload.class).object().value());
     }
 
     @Test
     public void testPipeline__shouldCompile_contextKeyOptional()
     {
-        Pipeline<Object, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKeyOptional("test-context-key-optional"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKeyOptional("test-context-key-optional"));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx
             .set("some-metadata", "my_value")
         ));
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertEquals("optional(my_value)", output.payload().object().value());
+        Assertions.assertEquals("optional(my_value)", output.payload(TestPayload.class).object().value());
     }
 
     @Test
     public void testPipeline__shouldCompile_contextKeyPrimitive()
     {
-        Pipeline<Object, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKeyPrimitive("test-context-key-primitive"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKeyPrimitive("test-context-key-primitive"));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx
             .set("some-primitive", 123)
         ));
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertEquals("primitive(123)", output.payload().object().value());
+        Assertions.assertEquals("primitive(123)", output.payload(TestPayload.class).object().value());
     }
 
     @Test
     public void testPipeline__shouldCompile_logMarker()
     {
-        Pipeline<Object, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_logMarker("test-log-marker"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_logMarker("test-log-marker"));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
             "init-with_log-marker",
-            output.payload().object().value()
+            output.payload(TestPayload.class).object().value()
         );
     }
 
-    public static Pipeline<Object, TestPayload> createPipeline_input(String name)
+    public static Pipeline<Object> createPipeline_input(String name)
     {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(new InitializerWithInput<>())
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, Initializer.of(new InitializerWithInput<>()))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .build()
         ;
     }
 
-    public static Pipeline<Object, TestPayload> createPipeline_input_assembler(String name)
+    public static Pipeline<Object> createPipeline_input_assembler(String name)
     {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(builder -> builder.initializer(new InitializerWithInput<>()))
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, builder -> builder.initializer(new InitializerWithInput<>()))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .build()
         ;
     }
 
-    public static Pipeline<Object, TestPayload> createPipeline_input_of(String name)
+    public static Pipeline<Object> createPipeline_input_exception(String name)
     {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(Initializer.of(new InitializerWithInput<>()))
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, Initializer.of(new InitializerWithException<>()))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .build()
         ;
     }
 
-    public static Pipeline<Object, TestPayload> createPipeline_input_exception(String name)
+    public static Pipeline<Object> createPipeline_tags(String name)
     {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(new InitializerWithException<>())
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, Initializer.of(new InitializerWithTags()))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .build()
         ;
     }
 
-    public static Pipeline<Object, TestPayload> createPipeline_tags(String name)
+    public static Pipeline<Object> createPipeline_context(String name, String metadataKey)
     {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(new InitializerWithTags())
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, Initializer.of(new InitializerWithContext(metadataKey)))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .build()
         ;
     }
 
-    public static Pipeline<Object, TestPayload> createPipeline_context(String name, String metadataKey)
+    public static Pipeline<Object> createPipeline_contextKey(String name)
     {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(new InitializerWithContext(metadataKey))
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, Initializer.of(new InitializerWithContextKey()))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .build()
         ;
     }
 
-    public static Pipeline<Object, TestPayload> createPipeline_contextKey(String name)
+    public static Pipeline<Object> createPipeline_contextKeyOptional(String name)
     {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(new InitializerWithContextKey())
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, Initializer.of(new InitializerWithContextKeyOptional()))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .build()
         ;
     }
 
-    public static Pipeline<Object, TestPayload> createPipeline_contextKeyOptional(String name)
+    public static Pipeline<Object> createPipeline_contextKeyPrimitive(String name)
     {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(new InitializerWithContextKeyOptional())
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, Initializer.of(new InitializerWithContextKeyPrimitive()))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .build()
         ;
     }
 
-    public static Pipeline<Object, TestPayload> createPipeline_contextKeyPrimitive(String name)
+    public static Pipeline<Object> createPipeline_logMarker(String name)
     {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(new InitializerWithContextKeyPrimitive())
-            .registerIndexer(TestPayload::object)
-            .build()
-        ;
-    }
-
-    public static Pipeline<Object, TestPayload> createPipeline_logMarker(String name)
-    {
-        return Pipeline.of(name, TestPayload.class)
-            .setInitializer(new InitializerWithLogMarker())
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, Initializer.of(new InitializerWithLogMarker()))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .build()
         ;
     }

--- a/src/test/java/tech/illuin/pipeline/input/initializer/annotation/PipelineInitializerIllegalAnnotationTest.java
+++ b/src/test/java/tech/illuin/pipeline/input/initializer/annotation/PipelineInitializerIllegalAnnotationTest.java
@@ -3,6 +3,7 @@ package tech.illuin.pipeline.input.initializer.annotation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import tech.illuin.pipeline.Pipeline;
+import tech.illuin.pipeline.input.initializer.Initializer;
 import tech.illuin.pipeline.input.initializer.annotation.initializer.*;
 
 /**
@@ -69,7 +70,7 @@ public class PipelineInitializerIllegalAnnotationTest
     {
         Assertions.assertThrows(IllegalStateException.class, () -> createNonCompilingPipeline(
             "test-non-compiling",
-            new IllegalInitializerIllegalArgumentOutput<>()
+            new IllegalInitializerIllegalArgumentOutput()
         ));
     }
 
@@ -91,10 +92,9 @@ public class PipelineInitializerIllegalAnnotationTest
         ));
     }
 
-    public static Pipeline<Object, ?> createNonCompilingPipeline(String name, Object illegalInitializer)
+    public static Pipeline<Object> createNonCompilingPipeline(String name, Object illegalInitializer)
     {
-        return Pipeline.of(name, Object.class)
-            .setInitializer(illegalInitializer)
+        return Pipeline.of(name, Initializer.of(illegalInitializer))
             .build()
         ;
     }

--- a/src/test/java/tech/illuin/pipeline/input/initializer/annotation/initializer/IllegalInitializerIllegalArgumentOutput.java
+++ b/src/test/java/tech/illuin/pipeline/input/initializer/annotation/initializer/IllegalInitializerIllegalArgumentOutput.java
@@ -11,12 +11,12 @@ import tech.illuin.pipeline.output.Output;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class IllegalInitializerIllegalArgumentOutput<T>
+public class IllegalInitializerIllegalArgumentOutput
 {
     private static final Logger logger = LoggerFactory.getLogger(IllegalInitializerIllegalArgumentOutput.class);
 
     @InitializerConfig
-    public TestPayload execute(Output<T> output, UIDGenerator generator)
+    public TestPayload execute(Output output, UIDGenerator generator)
     {
         logger.info("output: {}", output);
         return new TestPayload(new TestObject(generator.generate(), "illegal_output"));

--- a/src/test/java/tech/illuin/pipeline/input/initializer/annotation/initializer/InitializerWithContext.java
+++ b/src/test/java/tech/illuin/pipeline/input/initializer/annotation/initializer/InitializerWithContext.java
@@ -23,7 +23,7 @@ public class InitializerWithContext
     }
 
     @InitializerConfig(id = "init-with_context")
-    public TestPayload execute(Context<?> context, UIDGenerator generator)
+    public TestPayload execute(Context context, UIDGenerator generator)
     {
         logger.info("context: {}", context);
         return new TestPayload(new TestObject(generator.generate(), context.get(this.key, String.class).orElse(null)));

--- a/src/test/java/tech/illuin/pipeline/input/uid_generator/UIDGeneratorTest.java
+++ b/src/test/java/tech/illuin/pipeline/input/uid_generator/UIDGeneratorTest.java
@@ -59,7 +59,7 @@ public class UIDGeneratorTest
     {
         AtomicInteger counter = new AtomicInteger(0);
 
-        Pipeline<Object, ?> pipeline = createPipeline("test-ksuid", KSUIDGenerator.INSTANCE, uid -> {
+        Pipeline<Object> pipeline = createPipeline("test-ksuid", KSUIDGenerator.INSTANCE, uid -> {
             Assertions.assertEquals(uid.length(), 27);
             Assertions.assertEquals(Ksuid.from(uid).toString(), uid);
         }, counter);
@@ -75,7 +75,7 @@ public class UIDGeneratorTest
     {
         AtomicInteger counter = new AtomicInteger(0);
 
-        Pipeline<Object, ?> pipeline = createPipeline("test-ulid", ULIDGenerator.INSTANCE, uid -> {
+        Pipeline<Object> pipeline = createPipeline("test-ulid", ULIDGenerator.INSTANCE, uid -> {
             Assertions.assertEquals(uid.length(), 26);
             Assertions.assertEquals(Ulid.from(uid).toString(), uid);
         }, counter);
@@ -91,7 +91,7 @@ public class UIDGeneratorTest
     {
         AtomicInteger counter = new AtomicInteger(0);
 
-        Pipeline<Object, ?> pipeline = createPipeline("test-tsid", TSIDGenerator.INSTANCE, uid -> {
+        Pipeline<Object> pipeline = createPipeline("test-tsid", TSIDGenerator.INSTANCE, uid -> {
             Assertions.assertEquals(uid.length(), 13);
             Assertions.assertEquals(Tsid.from(uid).toString(), uid);
         }, counter);
@@ -107,7 +107,7 @@ public class UIDGeneratorTest
     {
         AtomicInteger counter = new AtomicInteger(0);
 
-        Pipeline<Object, ?> pipeline = createPipeline("test-uuid", UUIDGenerator.INSTANCE, uid -> {
+        Pipeline<Object> pipeline = createPipeline("test-uuid", UUIDGenerator.INSTANCE, uid -> {
             Assertions.assertEquals(uid.length(), 36);
             Assertions.assertEquals(UUID.fromString(uid).toString(), uid);
         }, counter);
@@ -118,7 +118,7 @@ public class UIDGeneratorTest
         Assertions.assertEquals(1, counter.get());
     }
 
-    private static Pipeline<Object, VoidPayload> createPipeline(String name, UIDGenerator generator, Consumer<String> uidTest, AtomicInteger counter)
+    private static Pipeline<Object> createPipeline(String name, UIDGenerator generator, Consumer<String> uidTest, AtomicInteger counter)
     {
         return Assertions.assertDoesNotThrow(() -> Pipeline.of(name)
             .setUidGenerator(generator)

--- a/src/test/java/tech/illuin/pipeline/output/factory/OutputFactoryTest.java
+++ b/src/test/java/tech/illuin/pipeline/output/factory/OutputFactoryTest.java
@@ -36,9 +36,9 @@ public class OutputFactoryTest
         Assertions.assertEquals(1, counter.get());
     }
 
-    private static class CustomOutput extends Output<B>
+    private static class CustomOutput extends Output
     {
-        public CustomOutput(PipelineTag tag, Void input, B payload, Context<B> context)
+        public CustomOutput(PipelineTag tag, Void input, Object payload, Context context)
         {
             super(tag, payload, context);
         }

--- a/src/test/java/tech/illuin/pipeline/sink/AnnotationTest.java
+++ b/src/test/java/tech/illuin/pipeline/sink/AnnotationTest.java
@@ -17,14 +17,14 @@ public class AnnotationTest
     {
         var counter = new AtomicInteger(0);
 
-        Pipeline<Void, ?> pipeline = Assertions.assertDoesNotThrow(() -> AnnotationTest.createAnnotatedPipeline(counter));
+        Pipeline<Void> pipeline = Assertions.assertDoesNotThrow(() -> AnnotationTest.createAnnotatedPipeline(counter));
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(1, counter.get());
     }
 
-    public static Pipeline<Void, ?> createAnnotatedPipeline(AtomicInteger counter)
+    public static Pipeline<Void> createAnnotatedPipeline(AtomicInteger counter)
     {
         return Pipeline.<Void>of("test-annotated")
             .registerSink(new TestAnnotatedSinks.ErrorHandler<>("1", in -> { throw new RuntimeException("Some error"); }))

--- a/src/test/java/tech/illuin/pipeline/sink/SinkErrorHandlerTest.java
+++ b/src/test/java/tech/illuin/pipeline/sink/SinkErrorHandlerTest.java
@@ -19,7 +19,7 @@ public class SinkErrorHandlerTest
         AtomicInteger successfulSinkCounter = new AtomicInteger(0);
         AtomicInteger failedSinkCounter = new AtomicInteger(0);
 
-        Pipeline<?, VoidPayload> pipeline = Assertions.assertDoesNotThrow(() -> createSinkErrorHandledPipeline(successfulSinkCounter, failedSinkCounter));
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(() -> createSinkErrorHandledPipeline(successfulSinkCounter, failedSinkCounter));
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
@@ -34,7 +34,7 @@ public class SinkErrorHandlerTest
         AtomicInteger failedSinkCounter = new AtomicInteger(0);
         AtomicInteger failedSinkErrorHandlerCounter = new AtomicInteger(0);
 
-        Pipeline<?, VoidPayload> pipeline = Assertions.assertDoesNotThrow(() -> createSinkErrorHandledPipelineWithTwoErrorHandlers(successfulSinkCounter, failedSinkCounter, failedSinkErrorHandlerCounter));
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(() -> createSinkErrorHandledPipelineWithTwoErrorHandlers(successfulSinkCounter, failedSinkCounter, failedSinkErrorHandlerCounter));
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
@@ -43,7 +43,7 @@ public class SinkErrorHandlerTest
         Assertions.assertEquals(1, failedSinkErrorHandlerCounter.get());
     }
 
-    public static Pipeline<?, VoidPayload> createSinkErrorHandledPipeline(AtomicInteger successfulSinkCounter, AtomicInteger failedSinkCounter)
+    public static Pipeline<?> createSinkErrorHandledPipeline(AtomicInteger successfulSinkCounter, AtomicInteger failedSinkCounter)
     {
         return Pipeline.of("test-sink-sync-exception")
             .registerSink((o, ctx) -> successfulSinkCounter.incrementAndGet())
@@ -56,7 +56,7 @@ public class SinkErrorHandlerTest
         ;
     }
 
-    public static Pipeline<?, VoidPayload> createSinkErrorHandledPipelineWithTwoErrorHandlers(AtomicInteger successfulSinkCounter, AtomicInteger failedSinkCounter, AtomicInteger failedSinkErrorHandlerCounter)
+    public static Pipeline<?> createSinkErrorHandledPipelineWithTwoErrorHandlers(AtomicInteger successfulSinkCounter, AtomicInteger failedSinkCounter, AtomicInteger failedSinkErrorHandlerCounter)
     {
         SinkErrorHandler firstErrorHandler = (ex, output, ctx) -> {
             failedSinkErrorHandlerCounter.incrementAndGet();

--- a/src/test/java/tech/illuin/pipeline/sink/SinkTest.java
+++ b/src/test/java/tech/illuin/pipeline/sink/SinkTest.java
@@ -17,7 +17,7 @@ public class SinkTest
     {
         var counter = new AtomicInteger(0);
 
-        Pipeline<?, VoidPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithSinks(counter));
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithSinks(counter));
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
@@ -29,7 +29,7 @@ public class SinkTest
     {
         var counter = new AtomicInteger(0);
 
-        Pipeline<?, VoidPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithSinks_syncException(counter));
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithSinks_syncException(counter));
         Assertions.assertThrows(Exception.class, pipeline::run);
         Assertions.assertDoesNotThrow(pipeline::close);
 
@@ -41,14 +41,14 @@ public class SinkTest
     {
         var counter = new AtomicInteger(0);
 
-        Pipeline<?, VoidPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithSinks_asyncException(counter));
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(() -> createPipelineWithSinks_asyncException(counter));
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(3, counter.get());
     }
 
-    public static Pipeline<?, VoidPayload> createPipelineWithSinks(AtomicInteger counter)
+    public static Pipeline<?> createPipelineWithSinks(AtomicInteger counter)
     {
         return Pipeline.of("test-sink")
            .registerSink((o, ctx) -> counter.incrementAndGet())
@@ -59,7 +59,7 @@ public class SinkTest
         ;
     }
 
-    public static Pipeline<?, VoidPayload> createPipelineWithSinks_syncException(AtomicInteger counter)
+    public static Pipeline<?> createPipelineWithSinks_syncException(AtomicInteger counter)
     {
         return Pipeline.of("test-sink-sync-exception")
             .registerSink((o, ctx) -> counter.incrementAndGet())
@@ -69,7 +69,7 @@ public class SinkTest
         ;
     }
 
-    public static Pipeline<?, VoidPayload> createPipelineWithSinks_asyncException(AtomicInteger counter)
+    public static Pipeline<?> createPipelineWithSinks_asyncException(AtomicInteger counter)
     {
         return Pipeline.of("test-sink-async-exception")
             .registerSink((o, ctx) -> counter.incrementAndGet())

--- a/src/test/java/tech/illuin/pipeline/sink/SinkWrapperTest.java
+++ b/src/test/java/tech/illuin/pipeline/sink/SinkWrapperTest.java
@@ -27,20 +27,20 @@ public class SinkWrapperTest
     {
         var counter = new AtomicInteger(0);
 
-        Pipeline<Void, A> pipeline = Assertions.assertDoesNotThrow(() -> SinkWrapperTest.createPipeline(counter));
+        Pipeline<Void> pipeline = Assertions.assertDoesNotThrow(() -> SinkWrapperTest.createPipeline(counter));
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(3, counter.get());
     }
 
-    public static Pipeline<Void, A> createPipeline(AtomicInteger counter)
+    public static Pipeline<Void> createPipeline(AtomicInteger counter)
     {
-        SinkWrapper<A> timeWrapper = new TimeLimiterWrapper<>(TimeLimiterConfig.custom()
+        SinkWrapper timeWrapper = new TimeLimiterWrapper<>(TimeLimiterConfig.custom()
             .timeoutDuration(Duration.ofMillis(200))
             .build()
         );
-        SinkWrapper<A> retryWrapper = new RetryWrapper<>(RetryConfig.custom()
+        SinkWrapper retryWrapper = new RetryWrapper<>(RetryConfig.custom()
             .maxAttempts(3)
             .waitDuration(Duration.ofMillis(25))
             .build()

--- a/src/test/java/tech/illuin/pipeline/sink/annotation/PipelineSinkAnnotationTest.java
+++ b/src/test/java/tech/illuin/pipeline/sink/annotation/PipelineSinkAnnotationTest.java
@@ -6,6 +6,7 @@ import tech.illuin.pipeline.Pipeline;
 import tech.illuin.pipeline.PipelineException;
 import tech.illuin.pipeline.generic.pipeline.TestResult;
 import tech.illuin.pipeline.input.indexer.Indexable;
+import tech.illuin.pipeline.input.indexer.SingleIndexer;
 import tech.illuin.pipeline.input.initializer.Initializer;
 import tech.illuin.pipeline.output.Output;
 import tech.illuin.pipeline.sink.Sink;
@@ -28,7 +29,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_input()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input("test-input", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input("test-input", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -40,7 +41,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_input_assembler()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_assembler("test-input", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_assembler("test-input", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -52,7 +53,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_input_of()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_of("test-input", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_of("test-input", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -63,7 +64,7 @@ public class PipelineSinkAnnotationTest
     @Test
     public void testPipeline__shouldCompile_input_exception()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_exception("test-input"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_exception("test-input"));
 
         PipelineException exception = Assertions.assertThrows(PipelineException.class, () -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -75,7 +76,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_inputAndReturnValue()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_returnValue("test-input-return-value", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_returnValue("test-input-return-value", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -87,31 +88,31 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_payload()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<String, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_payload("test-payload", collector));
+        Pipeline<String> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_payload("test-payload", collector));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertEquals(output.payload().object().uid(), collector.get());
+        Assertions.assertEquals(output.payload(TestPayload.class).object().uid(), collector.get());
     }
 
     @Test
     public void testPipeline__shouldCompile_output()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<String, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_output("test-output", collector));
+        Pipeline<String> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_output("test-output", collector));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertEquals(output.payload().object().uid(), collector.get());
+        Assertions.assertEquals(output.payload(TestPayload.class).object().uid(), collector.get());
     }
 
     @Test
     public void testPipeline__shouldCompile_current()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_current("test-current", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_current("test-current", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -123,7 +124,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_currentOptional()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentOptional("test-current-optional", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentOptional("test-current-optional", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -135,7 +136,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_currentStream()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentStream("test-current-stream", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentStream("test-current-stream", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -147,7 +148,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_currentNamed()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentNamed("test-current-named", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentNamed("test-current-named", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -159,7 +160,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_currentOptionalNamed()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentOptionalNamed("test-current-optional-named", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentOptionalNamed("test-current-optional-named", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -171,7 +172,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_currentStreamNamed()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentStreamNamed("test-current-stream-named", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentStreamNamed("test-current-stream-named", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -183,7 +184,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_latest()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latest("test-latest", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latest("test-latest", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -195,7 +196,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_latestOptional()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestOptional("test-latest-optional", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestOptional("test-latest-optional", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -207,7 +208,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_latestStream()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestStream("test-latest-stream", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestStream("test-latest-stream", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -219,7 +220,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_latestNamed()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestNamed("test-latest-named", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestNamed("test-latest-named", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -231,7 +232,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_latestOptionalNamed()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestOptionalNamed("test-latest-optional-named", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestOptionalNamed("test-latest-optional-named", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -243,7 +244,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_latestStreamNamed()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestStreamNamed("test-latest-stream-named", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestStreamNamed("test-latest-stream-named", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -255,7 +256,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_tags()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_tags("test-tags", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_tags("test-tags", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -267,7 +268,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_results()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_results("test-results", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_results("test-results", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -282,7 +283,7 @@ public class PipelineSinkAnnotationTest
         String value = "my_value";
 
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_context("test-context", key, collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_context("test-context", key, collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx.set(key, value)));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -294,7 +295,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_contextKey()
     {
         List<String> collector = new ArrayList<>();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKey("test-context-key", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKey("test-context-key", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx
             .set("some-metadata", "my_value")
@@ -314,7 +315,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_uidGenerator()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_uidGenerator("test-generator", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_uidGenerator("test-generator", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -326,7 +327,7 @@ public class PipelineSinkAnnotationTest
     public void testPipeline__shouldCompile_logMarker()
     {
         StringCollector collector = new StringCollector();
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_logMarker("test-log-marker", collector));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_logMarker("test-log-marker", collector));
 
         Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -334,7 +335,7 @@ public class PipelineSinkAnnotationTest
         Assertions.assertEquals("sink-with_log-marker", collector.get());
     }
 
-    public static Pipeline<Object, ?> createPipeline_input(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_input(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerSink(new SinkWithInput<>(collector))
@@ -342,7 +343,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_input_assembler(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_input_assembler(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerSink(builder -> builder.sink(new SinkWithInput<>(collector)))
@@ -350,7 +351,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_input_of(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_input_of(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerSink(Sink.of(new SinkWithInput<>(collector)))
@@ -358,7 +359,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_input_exception(String name)
+    public static Pipeline<Object> createPipeline_input_exception(String name)
     {
         return Pipeline.of(name)
             .registerSink(Sink.of(new SinkWithException<>()))
@@ -366,7 +367,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_input_returnValue(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_input_returnValue(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerSink(new SinkWithInputAndReturnValue<>(collector))
@@ -374,25 +375,25 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<String, TestPayload> createPipeline_payload(String name, StringCollector collector)
+    public static Pipeline<String> createPipeline_payload(String name, StringCollector collector)
     {
-        return Pipeline.of(name, (Initializer<String, TestPayload>) (input, context, generator) -> new TestPayload(new TestObject(generator.generate())))
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, (Initializer<String>) (input, context, generator) -> new TestPayload(new TestObject(generator.generate())))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .registerSink(new SinkWithPayload(collector))
             .build()
         ;
     }
 
-    public static Pipeline<String, TestPayload> createPipeline_output(String name, StringCollector collector)
+    public static Pipeline<String> createPipeline_output(String name, StringCollector collector)
     {
-        return Pipeline.of(name, (Initializer<String, TestPayload>) (input, context, generator) -> new TestPayload(new TestObject(generator.generate())))
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, (Initializer<String>) (input, context, generator) -> new TestPayload(new TestObject(generator.generate())))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .registerSink(new SinkWithOutput(collector))
             .build()
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_current(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_current(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -401,7 +402,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_currentOptional(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_currentOptional(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -410,7 +411,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_currentStream(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_currentStream(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -419,7 +420,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_currentNamed(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_currentNamed(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>("annotation-named"))
@@ -428,7 +429,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_currentOptionalNamed(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_currentOptionalNamed(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>("annotation-named"))
@@ -437,7 +438,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_currentStreamNamed(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_currentStreamNamed(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>("annotation-named"))
@@ -446,7 +447,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_latest(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_latest(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -455,7 +456,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_latestOptional(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_latestOptional(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -464,7 +465,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_latestStream(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_latestStream(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -473,7 +474,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_latestNamed(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_latestNamed(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>("annotation-named"))
@@ -482,7 +483,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_latestOptionalNamed(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_latestOptionalNamed(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>("annotation-named"))
@@ -491,7 +492,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_latestStreamNamed(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_latestStreamNamed(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>("annotation-named"))
@@ -500,7 +501,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_tags(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_tags(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerSink(new SinkWithTags(collector))
@@ -508,7 +509,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_results(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_results(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -517,7 +518,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_context(String name, String metadataKey, StringCollector collector)
+    public static Pipeline<Object> createPipeline_context(String name, String metadataKey, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerSink(new SinkWithContext(metadataKey, collector))
@@ -525,7 +526,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_contextKey(String name, List<String> collector)
+    public static Pipeline<Object> createPipeline_contextKey(String name, List<String> collector)
     {
         return Pipeline.of(name)
             .registerSink(new SinkWithContextKey(collector))
@@ -535,7 +536,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_uidGenerator(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_uidGenerator(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerSink(new SinkWithUIDGenerator(collector))
@@ -543,7 +544,7 @@ public class PipelineSinkAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_logMarker(String name, StringCollector collector)
+    public static Pipeline<Object> createPipeline_logMarker(String name, StringCollector collector)
     {
         return Pipeline.of(name)
             .registerSink(new SinkWithLogMarker(collector))

--- a/src/test/java/tech/illuin/pipeline/sink/annotation/PipelineSinkIllegalAnnotationTest.java
+++ b/src/test/java/tech/illuin/pipeline/sink/annotation/PipelineSinkIllegalAnnotationTest.java
@@ -56,7 +56,7 @@ public class PipelineSinkIllegalAnnotationTest
         ));
     }
 
-    public static Pipeline<Object, ?> createNonCompilingPipeline(String name, Object illegalSink)
+    public static Pipeline<Object> createNonCompilingPipeline(String name, Object illegalSink)
     {
         return Pipeline.of(name)
            .registerStep(builder -> builder.step(new StepWithInput<>()))

--- a/src/test/java/tech/illuin/pipeline/sink/annotation/sink/SinkWithContext.java
+++ b/src/test/java/tech/illuin/pipeline/sink/annotation/sink/SinkWithContext.java
@@ -23,7 +23,7 @@ public class SinkWithContext
     }
 
     @SinkConfig(id = "sink-with_context")
-    public void execute(Context<?> context)
+    public void execute(Context context)
     {
         logger.info("context: {}", context);
         this.collector.update(context.get(this.key, String.class).orElse(null));

--- a/src/test/java/tech/illuin/pipeline/sink/annotation/sink/SinkWithOutput.java
+++ b/src/test/java/tech/illuin/pipeline/sink/annotation/sink/SinkWithOutput.java
@@ -24,9 +24,9 @@ public class SinkWithOutput
     }
 
     @SinkConfig(id = "sink-with_output")
-    public void execute(Output<TestPayload> output)
+    public void execute(Output output)
     {
         logger.info("output: {}", output);
-        this.collector.update(Objects.toString(output.payload().object().uid()));
+        this.collector.update(Objects.toString(output.payload(TestPayload.class).object().uid()));
     }
 }

--- a/src/test/java/tech/illuin/pipeline/step/AnnotationTest.java
+++ b/src/test/java/tech/illuin/pipeline/step/AnnotationTest.java
@@ -21,11 +21,11 @@ public class AnnotationTest
     @Test
     public void testPipeline_withAnnotatedSteps()
     {
-        Pipeline<Void, A> pipeline = Assertions.assertDoesNotThrow(AnnotationTest::createAnnotatedPipeline);
-        Output<A> output = Assertions.assertDoesNotThrow(() -> pipeline.run());
+        Pipeline<Void> pipeline = Assertions.assertDoesNotThrow(AnnotationTest::createAnnotatedPipeline);
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertIterableEquals(List.of("1", "5", "error"), getResultTypes(output, output.payload()));
+        Assertions.assertIterableEquals(List.of("1", "5", "error"), getResultTypes(output, output.payload(A.class)));
 
         Assertions.assertEquals(1, output.results().size());
         Assertions.assertEquals(3, output.results().current().count());
@@ -38,7 +38,7 @@ public class AnnotationTest
         Assertions.assertTrue(output.results().current("5").isPresent());
     }
 
-    public static Pipeline<Void, A> createAnnotatedPipeline()
+    public static Pipeline<Void> createAnnotatedPipeline()
     {
         return Pipeline.of("test-annotated", TestFactory::initializerOfEmpty)
            .registerIndexer(SingleIndexer.auto())

--- a/src/test/java/tech/illuin/pipeline/step/ConditionTest.java
+++ b/src/test/java/tech/illuin/pipeline/step/ConditionTest.java
@@ -19,8 +19,8 @@ public class ConditionTest
     @Test
     public void testPipeline_shouldMatchEnabled()
     {
-        Pipeline<?, ?> pipeline = Assertions.assertDoesNotThrow(ConditionTest::createConditionalPipeline);
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run(null, ctx -> ctx.set("enabled", true)));
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(ConditionTest::createConditionalPipeline);
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run(null, ctx -> ctx.set("enabled", true)));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertIterableEquals(List.of("1", "3"), getResultTypes(output));
@@ -32,8 +32,8 @@ public class ConditionTest
     @Test
     public void testPipeline_shouldMatchDisabled()
     {
-        Pipeline<?, ?> pipeline = Assertions.assertDoesNotThrow(ConditionTest::createConditionalPipeline);
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run(null, ctx -> ctx.set("enabled", false)));
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(ConditionTest::createConditionalPipeline);
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run(null, ctx -> ctx.set("enabled", false)));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertIterableEquals(List.of("2", "3"), getResultTypes(output));
@@ -42,7 +42,7 @@ public class ConditionTest
         Assertions.assertTrue(output.results().current("3").isPresent());
     }
 
-    public static Pipeline<?, ?> createConditionalPipeline()
+    public static Pipeline<?> createConditionalPipeline()
     {
         return Pipeline.of("test-condition")
            .registerStep(builder -> builder

--- a/src/test/java/tech/illuin/pipeline/step/PinTest.java
+++ b/src/test/java/tech/illuin/pipeline/step/PinTest.java
@@ -7,6 +7,7 @@ import tech.illuin.pipeline.generic.TestFactory;
 import tech.illuin.pipeline.generic.model.A;
 import tech.illuin.pipeline.generic.pipeline.TestResult;
 import tech.illuin.pipeline.generic.pipeline.step.TestStep;
+import tech.illuin.pipeline.input.indexer.MultiIndexer;
 import tech.illuin.pipeline.input.indexer.SingleIndexer;
 import tech.illuin.pipeline.output.Output;
 import tech.illuin.pipeline.step.execution.evaluator.ResultEvaluator;
@@ -34,11 +35,11 @@ public class PinTest
 
     private void testPipeline_shouldHandleErrorWithPinned__runTest(ResultEvaluator evaluator, List<String> tags, int resultCount, Predicate<Optional<Result>> predicate4)
     {
-        Pipeline<Void, A> pipeline = Assertions.assertDoesNotThrow(() -> PinTest.createErrorHandledWithPinnedPipeline(evaluator));
-        Output<A> output = Assertions.assertDoesNotThrow(() -> pipeline.run());
+        Pipeline<Void> pipeline = Assertions.assertDoesNotThrow(() -> PinTest.createErrorHandledWithPinnedPipeline(evaluator));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertIterableEquals(tags, getResultTypes(output, output.payload()));
+        Assertions.assertIterableEquals(tags, getResultTypes(output, output.payload(A.class)));
 
         Assertions.assertEquals(1, output.results().size());
         Assertions.assertEquals(resultCount, output.results().current().count());
@@ -47,11 +48,11 @@ public class PinTest
         Assertions.assertTrue(output.results().current("error").isPresent());
     }
 
-    public static Pipeline<Void, A> createErrorHandledWithPinnedPipeline(ResultEvaluator evaluator)
+    public static Pipeline<Void> createErrorHandledWithPinnedPipeline(ResultEvaluator evaluator)
     {
         return Pipeline.of("test-error-handled-with-pinned", TestFactory::initializer)
            .registerIndexer(SingleIndexer.auto())
-           .registerIndexer(A::bs)
+           .registerIndexer((MultiIndexer<A>) A::bs)
            .registerStep(builder -> builder
                .step(new TestStep<>("1", "ok"))
                .withId("step-1")

--- a/src/test/java/tech/illuin/pipeline/step/PipelineStepTest.java
+++ b/src/test/java/tech/illuin/pipeline/step/PipelineStepTest.java
@@ -17,8 +17,8 @@ public class PipelineStepTest
     public void testPipeline__continue()
     {
         Counters counters = new Counters();
-        Pipeline<Object, ?> subPipeline = createPipeline("test-continue", (res, obj, in, ctx) -> StepStrategy.CONTINUE, counters);
-        Pipeline<Object, ?> pipeline = Pipeline.of("test-enclosing-continue").registerStep(subPipeline.asStep()).build();
+        Pipeline<Object> subPipeline = createPipeline("test-continue", (res, obj, in, ctx) -> StepStrategy.CONTINUE, counters);
+        Pipeline<Object> pipeline = Pipeline.of("test-enclosing-continue").registerStep(subPipeline.asStep()).build();
 
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -35,8 +35,8 @@ public class PipelineStepTest
     public void testPipeline__stop()
     {
         Counters counters = new Counters();
-        Pipeline<Object, ?> subPipeline = createPipeline("test-stop", (res, obj, in, ctx) -> StepStrategy.STOP, counters);
-        Pipeline<Object, ?> pipeline = Pipeline.of("test-enclosing-stop").registerStep(subPipeline.asStep()).build();
+        Pipeline<Object> subPipeline = createPipeline("test-stop", (res, obj, in, ctx) -> StepStrategy.STOP, counters);
+        Pipeline<Object> pipeline = Pipeline.of("test-enclosing-stop").registerStep(subPipeline.asStep()).build();
 
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -53,8 +53,8 @@ public class PipelineStepTest
     public void testPipeline__abort()
     {
         Counters counters = new Counters();
-        Pipeline<Object, ?> subPipeline = createPipeline("test-abort", (res, obj, in, ctx) -> StepStrategy.ABORT, counters);
-        Pipeline<Object, ?> pipeline = Pipeline.of("test-enclosing-abort").registerStep(subPipeline.asStep()).build();
+        Pipeline<Object> subPipeline = createPipeline("test-abort", (res, obj, in, ctx) -> StepStrategy.ABORT, counters);
+        Pipeline<Object> pipeline = Pipeline.of("test-enclosing-abort").registerStep(subPipeline.asStep()).build();
 
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -71,8 +71,8 @@ public class PipelineStepTest
     public void testPipeline__exit()
     {
         Counters counters = new Counters();
-        Pipeline<Object, ?> subPipeline = createPipeline("test-exit", (res, obj, in, ctx) -> StepStrategy.EXIT, counters);
-        Pipeline<Object, ?> pipeline = Pipeline.of("test-enclosing-exit").registerStep(subPipeline.asStep()).build();
+        Pipeline<Object> subPipeline = createPipeline("test-exit", (res, obj, in, ctx) -> StepStrategy.EXIT, counters);
+        Pipeline<Object> pipeline = Pipeline.of("test-enclosing-exit").registerStep(subPipeline.asStep()).build();
 
         Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);

--- a/src/test/java/tech/illuin/pipeline/step/StepWrapperRetryTest.java
+++ b/src/test/java/tech/illuin/pipeline/step/StepWrapperRetryTest.java
@@ -25,11 +25,11 @@ public class StepWrapperRetryTest
     @Test
     public void testPipeline_shouldRetryException()
     {
-        Pipeline<Void, A> pipeline = Assertions.assertDoesNotThrow(StepWrapperRetryTest::createErrorRetryPipeline);
-        Output<A> output = Assertions.assertDoesNotThrow(() -> pipeline.run());
+        Pipeline<Void> pipeline = Assertions.assertDoesNotThrow(StepWrapperRetryTest::createErrorRetryPipeline);
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertIterableEquals(List.of("1", "2", "3"), getResultTypes(output, output.payload()));
+        Assertions.assertIterableEquals(List.of("1", "2", "3"), getResultTypes(output, output.payload(A.class)));
 
         Assertions.assertEquals(1, output.results().size());
         Assertions.assertEquals(3, output.results().current().count());
@@ -39,7 +39,7 @@ public class StepWrapperRetryTest
         Assertions.assertTrue(output.results().current("3").isPresent());
     }
 
-    public static Pipeline<Void, A> createErrorRetryPipeline()
+    public static Pipeline<Void> createErrorRetryPipeline()
     {
         var counter = new AtomicInteger(0);
         return Pipeline.of("test-error-retry", TestFactory::initializerOfEmpty)

--- a/src/test/java/tech/illuin/pipeline/step/StepWrapperTest.java
+++ b/src/test/java/tech/illuin/pipeline/step/StepWrapperTest.java
@@ -30,11 +30,11 @@ public class StepWrapperTest
     @Test
     public void testPipeline_shouldCombineWrappers()
     {
-        Pipeline<Void, A> pipeline = Assertions.assertDoesNotThrow(StepWrapperTest::createPipeline);
-        Output<A> output = Assertions.assertDoesNotThrow(() -> pipeline.run());
+        Pipeline<Void> pipeline = Assertions.assertDoesNotThrow(StepWrapperTest::createPipeline);
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
-        Assertions.assertIterableEquals(List.of("1", "2", "3"), getResultTypes(output, output.payload()));
+        Assertions.assertIterableEquals(List.of("1", "2", "3"), getResultTypes(output, output.payload(A.class)));
 
         Assertions.assertEquals(1, output.results().size());
         Assertions.assertEquals(3, output.results().current().count());
@@ -44,13 +44,13 @@ public class StepWrapperTest
         Assertions.assertTrue(output.results().current("3").isPresent());
     }
 
-    public static Pipeline<Void, A> createPipeline()
+    public static Pipeline<Void> createPipeline()
     {
-        StepWrapper<Indexable, Void, A> timeWrapper = new TimeLimiterWrapper<>(TimeLimiterConfig.custom()
+        StepWrapper<Indexable, Void> timeWrapper = new TimeLimiterWrapper<>(TimeLimiterConfig.custom()
             .timeoutDuration(Duration.ofMillis(200))
             .build()
         );
-        StepWrapper<Indexable, Void, A> retryWrapper = new RetryWrapper<>(RetryConfig.custom()
+        StepWrapper<Indexable, Void> retryWrapper = new RetryWrapper<>(RetryConfig.custom()
             .maxAttempts(3)
             .waitDuration(Duration.ofMillis(25))
             .build()

--- a/src/test/java/tech/illuin/pipeline/step/StepWrapperTimeLimitTest.java
+++ b/src/test/java/tech/illuin/pipeline/step/StepWrapperTimeLimitTest.java
@@ -27,7 +27,7 @@ public class StepWrapperTimeLimitTest
     @Test
     public void testPipeline_shouldTimeout()
     {
-        Pipeline<?, VoidPayload> pipeline = Assertions.assertDoesNotThrow(() -> createTimeoutPipeline(StepWrapperTimeLimitTest::addTimeLimitedStep));
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(() -> createTimeoutPipeline(StepWrapperTimeLimitTest::addTimeLimitedStep));
 
         var ex = Assertions.assertThrows(RuntimeException.class, pipeline::run);
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -38,8 +38,8 @@ public class StepWrapperTimeLimitTest
     @Test
     public void testPipeline_shouldTimeoutThenBeHandled()
     {
-        Pipeline<?, VoidPayload> pipeline = Assertions.assertDoesNotThrow(() -> createTimeoutPipeline(StepWrapperTimeLimitTest::addTimeLimitedStepWithErrorHandler));
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run());
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(() -> createTimeoutPipeline(StepWrapperTimeLimitTest::addTimeLimitedStepWithErrorHandler));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run());
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertIterableEquals(List.of("1", "3", "timed-out"), getResultTypes(output));
@@ -52,7 +52,7 @@ public class StepWrapperTimeLimitTest
         Assertions.assertTrue(output.results().current("3").isPresent());
     }
 
-    public static Pipeline<?, VoidPayload> createTimeoutPipeline(StepAssembler<?, Object, VoidPayload> timeLimitedAssembler)
+    public static Pipeline<?> createTimeoutPipeline(StepAssembler<?, Object> timeLimitedAssembler)
     {
         return Pipeline.of("test-error-timelimit")
             .registerStep(new TestStep<>("1", "ok"))
@@ -62,7 +62,7 @@ public class StepWrapperTimeLimitTest
         ;
     }
 
-    public static void addTimeLimitedStep(StepBuilder<?, ?, ?> builder)
+    public static void addTimeLimitedStep(StepBuilder<?, ?> builder)
     {
         builder
             .step(new TestStep<>("2", b -> {
@@ -76,7 +76,7 @@ public class StepWrapperTimeLimitTest
         ;
     }
 
-    public static void addTimeLimitedStepWithErrorHandler(StepBuilder<?, ?, ?> builder)
+    public static void addTimeLimitedStepWithErrorHandler(StepBuilder<?, ?> builder)
     {
         addTimeLimitedStep(builder);
         builder.withErrorHandler((exception, input, payload, results, context) -> new TestResult("timed-out", "ko"));

--- a/src/test/java/tech/illuin/pipeline/step/annotation/PipelineStepAnnotationTest.java
+++ b/src/test/java/tech/illuin/pipeline/step/annotation/PipelineStepAnnotationTest.java
@@ -6,6 +6,7 @@ import tech.illuin.pipeline.Pipeline;
 import tech.illuin.pipeline.PipelineException;
 import tech.illuin.pipeline.generic.pipeline.TestResult;
 import tech.illuin.pipeline.input.indexer.Indexable;
+import tech.illuin.pipeline.input.indexer.SingleIndexer;
 import tech.illuin.pipeline.input.initializer.Initializer;
 import tech.illuin.pipeline.output.Output;
 import tech.illuin.pipeline.step.Step;
@@ -22,9 +23,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_input()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input("test-input"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input("test-input"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
@@ -36,9 +37,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_input_assembler()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_assembler("test-input"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_assembler("test-input"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
@@ -50,9 +51,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_input_of()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_of("test-input"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_of("test-input"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
@@ -64,7 +65,7 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_input_exception()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_exception("test-input"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_input_exception("test-input"));
 
         PipelineException exception = Assertions.assertThrows(PipelineException.class, () -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
@@ -75,13 +76,13 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_object()
     {
-        Pipeline<String, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_object("test-object"));
+        Pipeline<String> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_object("test-object"));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
-            output.payload().object().uid(),
+            output.payload(TestPayload.class).object().uid(),
             output.results().current(TestResult.class).map(TestResult::status).orElse(null)
         );
     }
@@ -89,13 +90,13 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_payload()
     {
-        Pipeline<String, TestPayload> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_payload("test-payload"));
+        Pipeline<String> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_payload("test-payload"));
 
-        Output<TestPayload> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
-            output.payload().object().uid(),
+            output.payload(TestPayload.class).object().uid(),
             output.results().current(TestResult.class).map(TestResult::status).orElse(null)
         );
     }
@@ -103,9 +104,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_current()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_current("test-current"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_current("test-current"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
@@ -117,9 +118,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_currentNamed()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentNamed("test-current-named"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_currentNamed("test-current-named"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         List<String> statuses = output.results().stream(TestResult.class)
@@ -140,9 +141,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_latest()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latest("test-latest"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latest("test-latest"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
@@ -154,9 +155,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_latestNamed()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestNamed("test-latest-named"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_latestNamed("test-latest-named"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         List<String> statuses = output.results().stream(TestResult.class)
@@ -177,9 +178,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_tags()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_tags("test-tags"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_tags("test-tags"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
@@ -191,9 +192,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_results()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_results("test-results"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_results("test-results"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(2, output.results().stream(TestResult.class).count());
@@ -206,9 +207,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_resultView()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_resultView("test-result_view"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_resultView("test-result_view"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(2, output.results().stream(TestResult.class).count());
@@ -224,9 +225,9 @@ public class PipelineStepAnnotationTest
         String key = "test_key";
         String value = "my_value";
 
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_context("test-context", key));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_context("test-context", key));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx.set(key, value)));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx.set(key, value)));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
@@ -238,9 +239,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_contextKey()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKey("test-context-key"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_contextKey("test-context-key"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input", ctx -> ctx
             .set("some-metadata", "my_value")
             .set("some-primitive", 123)
         ));
@@ -263,9 +264,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_uidGenerator()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_uidGenerator("test-uid-generator"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_uidGenerator("test-uid-generator"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
@@ -277,9 +278,9 @@ public class PipelineStepAnnotationTest
     @Test
     public void testPipeline__shouldCompile_logMarker()
     {
-        Pipeline<Object, ?> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_logMarker("test-log-marker"));
+        Pipeline<Object> pipeline = Assertions.assertDoesNotThrow(() -> createPipeline_logMarker("test-log-marker"));
 
-        Output<?> output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run("input"));
         Assertions.assertDoesNotThrow(pipeline::close);
 
         Assertions.assertEquals(
@@ -288,7 +289,7 @@ public class PipelineStepAnnotationTest
         );
     }
 
-    public static Pipeline<Object, ?> createPipeline_input(String name)
+    public static Pipeline<Object> createPipeline_input(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -296,7 +297,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_input_assembler(String name)
+    public static Pipeline<Object> createPipeline_input_assembler(String name)
     {
         return Pipeline.of(name)
             .registerStep(builder -> builder.step(new StepWithInput<>()))
@@ -304,7 +305,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_input_of(String name)
+    public static Pipeline<Object> createPipeline_input_of(String name)
     {
         return Pipeline.of(name)
             .registerStep(Step.of(new StepWithInput<>()))
@@ -312,7 +313,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_input_exception(String name)
+    public static Pipeline<Object> createPipeline_input_exception(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithException<>())
@@ -320,25 +321,25 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<String, TestPayload> createPipeline_object(String name)
+    public static Pipeline<String> createPipeline_object(String name)
     {
-        return Pipeline.of(name, (Initializer<String, TestPayload>) (input, context, generator) -> new TestPayload(new TestObject(generator.generate())))
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, (Initializer<String>) (input, context, generator) -> new TestPayload(new TestObject(generator.generate())))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .registerStep(new StepWithObject())
             .build()
         ;
     }
 
-    public static Pipeline<String, TestPayload> createPipeline_payload(String name)
+    public static Pipeline<String> createPipeline_payload(String name)
     {
-        return Pipeline.of(name, (Initializer<String, TestPayload>) (input, context, generator) -> new TestPayload(new TestObject(generator.generate())))
-            .registerIndexer(TestPayload::object)
+        return Pipeline.of(name, (Initializer<String>) (input, context, generator) -> new TestPayload(new TestObject(generator.generate())))
+            .registerIndexer((SingleIndexer<TestPayload>) TestPayload::object)
             .registerStep(new StepWithPayload())
             .build()
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_current(String name)
+    public static Pipeline<Object> createPipeline_current(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -349,7 +350,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_currentNamed(String name)
+    public static Pipeline<Object> createPipeline_currentNamed(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>("annotation-named"))
@@ -360,7 +361,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_latest(String name)
+    public static Pipeline<Object> createPipeline_latest(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -371,7 +372,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_latestNamed(String name)
+    public static Pipeline<Object> createPipeline_latestNamed(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>("annotation-named"))
@@ -382,7 +383,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_tags(String name)
+    public static Pipeline<Object> createPipeline_tags(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithTags())
@@ -390,7 +391,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_results(String name)
+    public static Pipeline<Object> createPipeline_results(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -400,7 +401,7 @@ public class PipelineStepAnnotationTest
     }
 
 
-    public static Pipeline<Object, ?> createPipeline_resultView(String name)
+    public static Pipeline<Object> createPipeline_resultView(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithInput<>())
@@ -409,7 +410,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_context(String name, String metadataKey)
+    public static Pipeline<Object> createPipeline_context(String name, String metadataKey)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithContext(metadataKey))
@@ -417,7 +418,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_contextKey(String name)
+    public static Pipeline<Object> createPipeline_contextKey(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithContextKey())
@@ -427,7 +428,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_uidGenerator(String name)
+    public static Pipeline<Object> createPipeline_uidGenerator(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithUIDGenerator())
@@ -435,7 +436,7 @@ public class PipelineStepAnnotationTest
         ;
     }
 
-    public static Pipeline<Object, ?> createPipeline_logMarker(String name)
+    public static Pipeline<Object> createPipeline_logMarker(String name)
     {
         return Pipeline.of(name)
             .registerStep(new StepWithLogMarker())

--- a/src/test/java/tech/illuin/pipeline/step/annotation/PipelineStepIllegalAnnotationTest.java
+++ b/src/test/java/tech/illuin/pipeline/step/annotation/PipelineStepIllegalAnnotationTest.java
@@ -51,11 +51,11 @@ public class PipelineStepIllegalAnnotationTest
     {
         Assertions.assertThrows(IllegalStateException.class, () -> createNonCompilingPipeline(
             "test-non-compiling",
-            new IllegalStepIllegalArgumentOutput<>()
+            new IllegalStepIllegalArgumentOutput()
         ));
     }
 
-    public static Pipeline<Object, ?> createNonCompilingPipeline(String name, Object illegalStep)
+    public static Pipeline<Object> createNonCompilingPipeline(String name, Object illegalStep)
     {
         return Pipeline.of(name)
            .registerStep(builder -> builder.step(new StepWithInput<>()))

--- a/src/test/java/tech/illuin/pipeline/step/annotation/step/IllegalStepIllegalArgumentOutput.java
+++ b/src/test/java/tech/illuin/pipeline/step/annotation/step/IllegalStepIllegalArgumentOutput.java
@@ -12,12 +12,12 @@ import java.util.Objects;
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
-public class IllegalStepIllegalArgumentOutput<T>
+public class IllegalStepIllegalArgumentOutput
 {
     private static final Logger logger = LoggerFactory.getLogger(IllegalStepIllegalArgumentOutput.class);
 
     @StepConfig
-    public Result execute(Output<T> output)
+    public Result execute(Output output)
     {
         logger.info("output: {}", output);
         return new TestResult("test-annotation", Objects.toString(output));

--- a/src/test/java/tech/illuin/pipeline/step/annotation/step/StepWithContext.java
+++ b/src/test/java/tech/illuin/pipeline/step/annotation/step/StepWithContext.java
@@ -22,7 +22,7 @@ public class StepWithContext
     }
 
     @StepConfig(id = "step-with_context")
-    public Result execute(Context<?> context)
+    public Result execute(Context context)
     {
         logger.info("context: {}", context);
         return new TestResult("annotation-test", context.get(this.key, String.class).orElse(null));


### PR DESCRIPTION
This is an attempt at a new version of the `data-pipeline` API without payload related arguments in generic types.

This is an extensive change that introduces BC-breaks all over the place, but makes for a much simpler experience. This ought to be tested in several projects before we go ahead and merge.