### PR TITLE
feat: add Interruption result type along with X_ON_INTERRUPT default evaluators

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The library requires Java 17+, in order to use it, add the following in your `po
 <dependency>
     <groupId>tech.illuin</groupId>
     <artifactId>data-pipeline</artifactId>
-    <version>0.17</version>
+    <version>0.18-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/core/src/main/java/tech/illuin/pipeline/CompositePipeline.java
+++ b/core/src/main/java/tech/illuin/pipeline/CompositePipeline.java
@@ -136,7 +136,7 @@ public final class CompositePipeline<I> implements Pipeline<I>
             metrics.failureCounter().increment();
             metrics.errorCounter(e).increment();
             logger.error(metrics.mark(e), "{}: {}", this.id(), e.getMessage());
-            return this.errorHandler.handle(e, output, input, context);
+            return this.errorHandler.handle(e, output, input, context, tag);
         }
         finally {
             metrics.runTimer().record(System.nanoTime() - start, TimeUnit.NANOSECONDS);

--- a/core/src/main/java/tech/illuin/pipeline/PipelineException.java
+++ b/core/src/main/java/tech/illuin/pipeline/PipelineException.java
@@ -1,12 +1,30 @@
 package tech.illuin.pipeline;
 
+import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.output.PipelineTag;
+
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 public class PipelineException extends Exception
 {
-    public PipelineException(String message, Throwable cause)
+    private final PipelineTag tag;
+    private final Context context;
+
+    public PipelineException(PipelineTag tag, Context context, String message, Throwable cause)
     {
         super(message, cause);
+        this.tag = tag;
+        this.context = context;
+    }
+
+    public PipelineTag tag()
+    {
+        return this.tag;
+    }
+
+    public Context context()
+    {
+        return this.context;
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/execution/error/PipelineErrorHandler.java
+++ b/core/src/main/java/tech/illuin/pipeline/execution/error/PipelineErrorHandler.java
@@ -3,28 +3,29 @@ package tech.illuin.pipeline.execution.error;
 import tech.illuin.pipeline.PipelineException;
 import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.output.Output;
+import tech.illuin.pipeline.output.PipelineTag;
 
 public interface PipelineErrorHandler
 {
-    Output handle(Exception exception, Output previous, Object input, Context context) throws PipelineException;
+    Output handle(Exception exception, Output previous, Object input, Context context, PipelineTag tag) throws PipelineException;
 
     @SuppressWarnings("IllegalCatch")
     default PipelineErrorHandler andThen(PipelineErrorHandler nextErrorHandler)
     {
-        return (Exception ex, Output previous, Object input, Context context) -> {
+        return (Exception ex, Output previous, Object input, Context context, PipelineTag tag) -> {
             try {
-                return this.handle(ex, previous, input, context);
+                return this.handle(ex, previous, input, context, tag);
             }
             catch (Exception e) {
-                return nextErrorHandler.handle(e, previous, input, context);
+                return nextErrorHandler.handle(e, previous, input, context, tag);
             }
         };
     }
 
-    static  Output wrapChecked(Exception ex, Output previous, Object input, Context context) throws PipelineException
+    static Output wrapChecked(Exception ex, Output previous, Object input, Context context, PipelineTag tag) throws PipelineException
     {
         if (ex instanceof RuntimeException re)
             throw re;
-        throw new PipelineException(ex.getMessage(), ex);
+        throw new PipelineException(tag, context, ex.getMessage(), ex);
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/execution/error/PipelineErrorHandler.java
+++ b/core/src/main/java/tech/illuin/pipeline/execution/error/PipelineErrorHandler.java
@@ -5,6 +5,8 @@ import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.output.Output;
 import tech.illuin.pipeline.output.PipelineTag;
 
+import java.util.Collection;
+
 public interface PipelineErrorHandler
 {
     Output handle(Exception exception, Output previous, Object input, Context context, PipelineTag tag) throws PipelineException;
@@ -27,5 +29,15 @@ public interface PipelineErrorHandler
         if (ex instanceof RuntimeException re)
             throw re;
         throw new PipelineException(tag, context, ex.getMessage(), ex);
+    }
+
+    static <E extends Throwable> void throwUnlessExcepted(E exception, Collection<Class<? extends Throwable>> except) throws E
+    {
+        for (Class<? extends Throwable> excepted : except)
+        {
+            if (excepted.isInstance(exception))
+                return;
+        }
+        throw exception;
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/input/initializer/execution/error/InitializerErrorHandler.java
+++ b/core/src/main/java/tech/illuin/pipeline/input/initializer/execution/error/InitializerErrorHandler.java
@@ -3,6 +3,12 @@ package tech.illuin.pipeline.input.initializer.execution.error;
 import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.input.indexer.Indexable;
 import tech.illuin.pipeline.input.uid_generator.UIDGenerator;
+import tech.illuin.pipeline.sink.execution.error.SinkErrorHandler;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static tech.illuin.pipeline.execution.error.PipelineErrorHandler.throwUnlessExcepted;
 
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
@@ -15,4 +21,18 @@ public interface InitializerErrorHandler
     InitializerErrorHandler RETHROW_ALL = (ex, ctx, gen) -> {
         throw ex;
     };
+
+    @SafeVarargs
+    static InitializerErrorHandler rethrowAllExcept(InitializerErrorHandler wrapper, Class<? extends Throwable>... except)
+    {
+        return rethrowAllExcept(wrapper, Arrays.asList(except));
+    }
+
+    static InitializerErrorHandler rethrowAllExcept(InitializerErrorHandler wrapper, Collection<Class<? extends Throwable>> except)
+    {
+        return (ex, ctx, gen) -> {
+            throwUnlessExcepted(ex, except);
+            return wrapper.handle(ex, ctx, gen);
+        };
+    }
 }

--- a/core/src/main/java/tech/illuin/pipeline/sink/execution/error/SinkErrorHandler.java
+++ b/core/src/main/java/tech/illuin/pipeline/sink/execution/error/SinkErrorHandler.java
@@ -2,6 +2,13 @@ package tech.illuin.pipeline.sink.execution.error;
 
 import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.output.Output;
+import tech.illuin.pipeline.step.execution.error.StepErrorHandler;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static tech.illuin.pipeline.execution.error.PipelineErrorHandler.throwUnlessExcepted;
 
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
@@ -26,5 +33,16 @@ public interface SinkErrorHandler
                 nextErrorHandler.handle(e, output, context);
             }
         };
+    }
+
+    @SafeVarargs
+    static SinkErrorHandler rethrowAllExcept(Class<? extends Throwable>... except)
+    {
+        return rethrowAllExcept(Arrays.asList(except));
+    }
+
+    static SinkErrorHandler rethrowAllExcept(Collection<Class<? extends Throwable>> except)
+    {
+        return (ex, out, ctx) -> throwUnlessExcepted(ex, except);
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/step/execution/error/StepErrorHandler.java
+++ b/core/src/main/java/tech/illuin/pipeline/step/execution/error/StepErrorHandler.java
@@ -4,6 +4,13 @@ import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.step.result.Result;
 import tech.illuin.pipeline.step.result.Results;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Function;
+
+import static tech.illuin.pipeline.execution.error.PipelineErrorHandler.throwUnlessExcepted;
+
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
@@ -26,6 +33,20 @@ public interface StepErrorHandler
             catch (Exception e) {
                 return nextErrorHandler.handle(e, input, payload, results, context);
             }
+        };
+    }
+
+    @SafeVarargs
+    static StepErrorHandler rethrowAllExcept(StepErrorHandler wrapper, Class<? extends Throwable>... except)
+    {
+        return rethrowAllExcept(wrapper, Arrays.asList(except));
+    }
+
+    static StepErrorHandler rethrowAllExcept(StepErrorHandler wrapper, Collection<Class<? extends Throwable>> except)
+    {
+        return (ex, in, payload, res, ctx) -> {
+            throwUnlessExcepted(ex, except);
+            return wrapper.handle(ex, in, payload, res, ctx);
         };
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/step/execution/evaluator/ResultEvaluator.java
+++ b/core/src/main/java/tech/illuin/pipeline/step/execution/evaluator/ResultEvaluator.java
@@ -2,6 +2,7 @@ package tech.illuin.pipeline.step.execution.evaluator;
 
 import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.input.indexer.Indexable;
+import tech.illuin.pipeline.step.execution.interruption.Interruption;
 import tech.illuin.pipeline.step.result.Result;
 
 /**
@@ -16,6 +17,10 @@ public interface ResultEvaluator
     ResultEvaluator ALWAYS_ABORT = ResultEvaluator::alwaysAbort;
     ResultEvaluator ALWAYS_STOP = ResultEvaluator::alwaysStop;
     ResultEvaluator ALWAYS_DISCARD = ResultEvaluator::alwaysDiscard;
+    ResultEvaluator SKIP_ON_INTERRUPT = ResultEvaluator::skipOnInterrupt;
+    ResultEvaluator ABORT_ON_INTERRUPT = ResultEvaluator::abortOnInterrupt;
+    ResultEvaluator STOP_ON_INTERRUPT = ResultEvaluator::stopOnInterrupt;
+    ResultEvaluator DISCARD_ON_INTERRUPT = ResultEvaluator::discardOnInterrupt;
 
     private static StepStrategy alwaysContinue(Result result, Indexable object, Object input, Context ctx)
     {
@@ -40,5 +45,33 @@ public interface ResultEvaluator
     private static StepStrategy alwaysDiscard(Result result, Indexable object, Object input, Context ctx)
     {
         return StepStrategy.DISCARD_AND_CONTINUE;
+    }
+
+    private static StepStrategy skipOnInterrupt(Result result, Indexable object, Object input, Context ctx)
+    {
+        if (result instanceof Interruption)
+            return StepStrategy.SKIP;
+        return StepStrategy.CONTINUE;
+    }
+
+    private static StepStrategy abortOnInterrupt(Result result, Indexable object, Object input, Context ctx)
+    {
+        if (result instanceof Interruption)
+            return StepStrategy.ABORT;
+        return StepStrategy.CONTINUE;
+    }
+
+    private static StepStrategy stopOnInterrupt(Result result, Indexable object, Object input, Context ctx)
+    {
+        if (result instanceof Interruption)
+            return StepStrategy.STOP;
+        return StepStrategy.CONTINUE;
+    }
+
+    private static StepStrategy discardOnInterrupt(Result result, Indexable object, Object input, Context ctx)
+    {
+        if (result instanceof Interruption)
+            return StepStrategy.DISCARD_AND_CONTINUE;
+        return StepStrategy.CONTINUE;
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/step/execution/interruption/Interruption.java
+++ b/core/src/main/java/tech/illuin/pipeline/step/execution/interruption/Interruption.java
@@ -4,8 +4,14 @@ import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.output.ComponentTag;
 import tech.illuin.pipeline.step.result.Result;
 
-public record Interruption(
-    ComponentTag tag,
-    Context context,
-    String message
-) implements Result {}
+public interface Interruption extends Result
+{
+    ComponentTag tag();
+    Context context();
+    String message();
+
+    static Interruption of(ComponentTag tag, Context context, String message)
+    {
+        return new SimpleInterruption(tag, context, message);
+    }
+}

--- a/core/src/main/java/tech/illuin/pipeline/step/execution/interruption/Interruption.java
+++ b/core/src/main/java/tech/illuin/pipeline/step/execution/interruption/Interruption.java
@@ -1,0 +1,11 @@
+package tech.illuin.pipeline.step.execution.interruption;
+
+import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.output.ComponentTag;
+import tech.illuin.pipeline.step.result.Result;
+
+public record Interruption(
+    ComponentTag tag,
+    Context context,
+    String message
+) implements Result {}

--- a/core/src/main/java/tech/illuin/pipeline/step/execution/interruption/SimpleInterruption.java
+++ b/core/src/main/java/tech/illuin/pipeline/step/execution/interruption/SimpleInterruption.java
@@ -1,0 +1,10 @@
+package tech.illuin.pipeline.step.execution.interruption;
+
+import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.output.ComponentTag;
+
+record SimpleInterruption(
+    ComponentTag tag,
+    Context context,
+    String message
+) implements Interruption {}

--- a/core/src/test/java/tech/illuin/pipeline/input/initializer/execution/error/InitializerErrorHandlerTest.java
+++ b/core/src/test/java/tech/illuin/pipeline/input/initializer/execution/error/InitializerErrorHandlerTest.java
@@ -1,0 +1,31 @@
+package tech.illuin.pipeline.input.initializer.execution.error;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import tech.illuin.pipeline.generic.model.A;
+import tech.illuin.pipeline.input.indexer.Indexable;
+
+import static java.util.Collections.emptyList;
+
+public class InitializerErrorHandlerTest
+{
+    @Test
+    public void testRethrowAllExcept()
+    {
+        InitializerErrorHandler handler = InitializerErrorHandler.rethrowAllExcept(
+            (exception, context, generator) -> new A("abc", emptyList()),
+            IllegalStateException.class,
+            IllegalArgumentException.class
+        );
+
+        Assertions.assertThrows(RuntimeException.class, () -> handler.handle(new RuntimeException(), null, null));
+
+        Indexable illegalStateResult = Assertions.assertDoesNotThrow(() -> handler.handle(new IllegalStateException(), null, null));
+        A illegalStateA = Assertions.assertInstanceOf(A.class, illegalStateResult);
+        Assertions.assertEquals("abc", illegalStateA.uid());
+
+        Indexable illegalArgResult = Assertions.assertDoesNotThrow(() -> handler.handle(new IllegalArgumentException(), null, null));
+        A illegalArgA = Assertions.assertInstanceOf(A.class, illegalArgResult);
+        Assertions.assertEquals("abc", illegalArgA.uid());
+    }
+}

--- a/core/src/test/java/tech/illuin/pipeline/sink/execution/error/SinkErrorHandlerTest.java
+++ b/core/src/test/java/tech/illuin/pipeline/sink/execution/error/SinkErrorHandlerTest.java
@@ -1,0 +1,25 @@
+package tech.illuin.pipeline.sink.execution.error;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import tech.illuin.pipeline.generic.pipeline.TestResult;
+import tech.illuin.pipeline.step.execution.error.StepErrorHandler;
+import tech.illuin.pipeline.step.result.Result;
+
+public class SinkErrorHandlerTest
+{
+    @Test
+    public void testRethrowAllExcept()
+    {
+        SinkErrorHandler handler = SinkErrorHandler.rethrowAllExcept(
+            IllegalStateException.class,
+            IllegalArgumentException.class
+        );
+
+        Assertions.assertThrows(RuntimeException.class, () -> handler.handle(new RuntimeException(), null, null));
+
+        Assertions.assertDoesNotThrow(() -> handler.handle(new IllegalStateException(), null, null));
+
+        Assertions.assertDoesNotThrow(() -> handler.handle(new IllegalArgumentException(), null, null));
+    }
+}

--- a/core/src/test/java/tech/illuin/pipeline/step/EvaluationTest.java
+++ b/core/src/test/java/tech/illuin/pipeline/step/EvaluationTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import tech.illuin.pipeline.Pipeline;
 import tech.illuin.pipeline.builder.VoidPayload;
+import tech.illuin.pipeline.context.ComponentContext;
+import tech.illuin.pipeline.context.Context;
 import tech.illuin.pipeline.generic.TestFactory;
 import tech.illuin.pipeline.generic.model.A;
 import tech.illuin.pipeline.generic.model.B;
@@ -11,13 +13,19 @@ import tech.illuin.pipeline.generic.pipeline.TestResult;
 import tech.illuin.pipeline.generic.pipeline.step.TestStep;
 import tech.illuin.pipeline.input.indexer.MultiIndexer;
 import tech.illuin.pipeline.input.indexer.SingleIndexer;
+import tech.illuin.pipeline.output.ComponentTag;
 import tech.illuin.pipeline.output.Output;
+import tech.illuin.pipeline.step.execution.evaluator.ResultEvaluator;
+import tech.illuin.pipeline.step.execution.interruption.Interruption;
+import tech.illuin.pipeline.step.result.Result;
+import tech.illuin.pipeline.step.result.ResultView;
+import tech.illuin.pipeline.step.variant.InputStep;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static tech.illuin.pipeline.generic.Tests.getResultTypes;
-import static tech.illuin.pipeline.step.execution.evaluator.ResultEvaluator.ALWAYS_SKIP;
+import static tech.illuin.pipeline.step.execution.evaluator.ResultEvaluator.*;
 import static tech.illuin.pipeline.step.execution.evaluator.StepStrategy.*;
 
 /**
@@ -67,6 +75,63 @@ public class EvaluationTest
 
         Assertions.assertEquals(1, counter.get());
         Assertions.assertEquals(0, output.results().stream().count());
+    }
+
+    @Test
+    public void testPipeline_shouldSkipOnInterrupt()
+    {
+        testPipeline__onInterrupt("test-evaluation-skip-on-interrupt", SKIP_ON_INTERRUPT, false, 2, TestResult.class);
+        testPipeline__onInterrupt("test-evaluation-skip-on-interrupt", SKIP_ON_INTERRUPT, true, 1, TestResult.class);
+    }
+
+    @Test
+    public void testPipeline_shouldAbortOnInterrupt()
+    {
+        testPipeline__onInterrupt("test-evaluation-abort-on-interrupt", ABORT_ON_INTERRUPT, false, 2, TestResult.class);
+        testPipeline__onInterrupt("test-evaluation-abort-on-interrupt", ABORT_ON_INTERRUPT, true, 1, Interruption.class);
+    }
+
+    @Test
+    public void testPipeline_shouldStopOnInterrupt()
+    {
+        testPipeline__onInterrupt("test-evaluation-stop-on-interrupt", STOP_ON_INTERRUPT, false, 2, TestResult.class);
+        testPipeline__onInterrupt("test-evaluation-stop-on-interrupt", STOP_ON_INTERRUPT, true, 1, Interruption.class);
+    }
+
+    @Test
+    public void testPipeline_shouldDiscardOnInterrupt()
+    {
+        testPipeline__onInterrupt("test-evaluation-discard-on-interrupt", DISCARD_ON_INTERRUPT, false,2, TestResult.class);
+        testPipeline__onInterrupt("test-evaluation-discard-on-interrupt", DISCARD_ON_INTERRUPT, true,1, Interruption.class);
+    }
+
+    private static void testPipeline__onInterrupt(String name, ResultEvaluator evaluator, boolean interrupt, int resultCount, Class<?> resultType)
+    {
+        AtomicInteger counter = new AtomicInteger(0);
+
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(() -> Pipeline.of(name)
+            .registerStep(builder -> builder
+                .step((InputStep<Object>) (input, results, context) -> {
+                    counter.incrementAndGet();
+                    if (context.get("do_interrupt", Boolean.class).orElse(false))
+                    {
+                        ComponentTag tag = ((ComponentContext) context).componentTag();
+                        return new Interruption(tag, context, "stop");
+                    }
+                    return new TestResult("1", "ok");
+                })
+            )
+            .registerStep(builder -> builder.step(new TestStep<>("2", "ok")))
+            .setDefaultEvaluator(evaluator)
+            .build()
+        );
+
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run(null, ctx -> ctx.set("do_interrupt", interrupt)));
+        Assertions.assertDoesNotThrow(pipeline::close);
+
+        Assertions.assertEquals(1, counter.get());
+        Assertions.assertEquals(resultCount, output.results().stream().count());
+        Assertions.assertInstanceOf(resultType, output.results().stream().findFirst().orElse(null));
     }
 
     public static Pipeline<Void> createAbortingPipeline()

--- a/core/src/test/java/tech/illuin/pipeline/step/EvaluationTest.java
+++ b/core/src/test/java/tech/illuin/pipeline/step/EvaluationTest.java
@@ -116,7 +116,7 @@ public class EvaluationTest
                     if (context.get("do_interrupt", Boolean.class).orElse(false))
                     {
                         ComponentTag tag = ((ComponentContext) context).componentTag();
-                        return new Interruption(tag, context, "stop");
+                        return Interruption.of(tag, context, "stop");
                     }
                     return new TestResult("1", "ok");
                 })

--- a/core/src/test/java/tech/illuin/pipeline/step/execution/error/StepErrorHandlerTest.java
+++ b/core/src/test/java/tech/illuin/pipeline/step/execution/error/StepErrorHandlerTest.java
@@ -1,0 +1,36 @@
+package tech.illuin.pipeline.step.execution.error;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.generic.model.A;
+import tech.illuin.pipeline.generic.pipeline.TestResult;
+import tech.illuin.pipeline.input.indexer.Indexable;
+import tech.illuin.pipeline.input.initializer.execution.error.InitializerErrorHandler;
+import tech.illuin.pipeline.step.result.Result;
+import tech.illuin.pipeline.step.result.Results;
+
+import static java.util.Collections.emptyList;
+
+public class StepErrorHandlerTest
+{
+    @Test
+    public void testRethrowAllExcept()
+    {
+        StepErrorHandler handler = StepErrorHandler.rethrowAllExcept(
+            (exception, input, payload, results, context) -> new TestResult("abc", "def"),
+            IllegalStateException.class,
+            IllegalArgumentException.class
+        );
+
+        Assertions.assertThrows(RuntimeException.class, () -> handler.handle(new RuntimeException(), null, null, null, null));
+
+        Result illegalStateResult = Assertions.assertDoesNotThrow(() -> handler.handle(new IllegalStateException(), null, null, null, null));
+        TestResult illegalStateA = Assertions.assertInstanceOf(TestResult.class, illegalStateResult);
+        Assertions.assertEquals("abc", illegalStateA.name());
+
+        Result illegalArgResult = Assertions.assertDoesNotThrow(() -> handler.handle(new IllegalArgumentException(), null, null, null, null));
+        TestResult illegalArgA = Assertions.assertInstanceOf(TestResult.class, illegalArgResult);
+        Assertions.assertEquals("abc", illegalArgA.name());
+    }
+}

--- a/doc/integrations.md
+++ b/doc/integrations.md
@@ -139,7 +139,7 @@ Here is an example of one such dashboard in action:
 <dependency>
     <groupId>tech.illuin</groupId>
     <artifactId>data-pipeline-resilience4j</artifactId>
-    <version>0.17</version>
+    <version>0.18-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Adding interruption mechanisms making it simpler to setup pipelines where instead of throwing an Exception in case of an error, we want to stop the pipeline and exit the pipeline in an orderly manner.

This was already possible through combinations of `StepErrorHandler`, `ResultEvalutor` and `PipelineErrorHandler`, but resulted in projects needing to reimplement similar generic components over and over.

With the current implementation it is possible to simply return an `Interruption` result, and use one of the new default `ResultEvaluator` implementations:

* `SKIP_ON_INTERRUPT`
* `ABORT_ON_INTERRUPT`
* `STOP_ON_INTERRUPT`
* `DISCARD_ON_INTERRUPT`