### PR TITLE
feat: new MultiResult wrapper

### DIFF
--- a/core/src/main/java/tech/illuin/pipeline/step/result/MultiResult.java
+++ b/core/src/main/java/tech/illuin/pipeline/step/result/MultiResult.java
@@ -1,0 +1,23 @@
+package tech.illuin.pipeline.step.result;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public interface MultiResult extends Result
+{
+    Collection<? extends Result> results();
+
+    static MultiResult of(Result... results)
+    {
+        return of(Arrays.asList(results));
+    }
+
+    static MultiResult of(Collection<? extends Result> results)
+    {
+        return new AnonymousMultiResult(results);
+    }
+
+    record AnonymousMultiResult(
+        Collection<? extends Result> results
+    ) implements MultiResult {}
+}

--- a/core/src/test/java/tech/illuin/pipeline/generic/pipeline/step/TestMultiStep.java
+++ b/core/src/test/java/tech/illuin/pipeline/generic/pipeline/step/TestMultiStep.java
@@ -1,0 +1,42 @@
+package tech.illuin.pipeline.generic.pipeline.step;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.generic.pipeline.TestResult;
+import tech.illuin.pipeline.input.indexer.Indexable;
+import tech.illuin.pipeline.step.annotation.StepConfig;
+import tech.illuin.pipeline.step.result.MultiResult;
+import tech.illuin.pipeline.step.result.Result;
+import tech.illuin.pipeline.step.result.ResultView;
+import tech.illuin.pipeline.step.variant.IndexableStep;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
+ */
+@StepConfig(id = "test-multi-step")
+public class TestMultiStep<T extends Indexable> implements IndexableStep<T>
+{
+    private final String name;
+    private final Function<T, List<String>> function;
+
+    private static final Logger logger = LoggerFactory.getLogger(TestMultiStep.class);
+
+    public TestMultiStep(String name, Function<T, List<String>> function)
+    {
+        this.name = name;
+        this.function = function;
+    }
+
+    @Override
+    public MultiResult execute(T data, ResultView results, Context context)
+    {
+        logger.info("test:{}: {}", this.name, data);
+        List<String> values = this.function.apply(data);
+        return MultiResult.of(values.stream().map(v -> new TestResult(this.name, v)).toList());
+    }
+}

--- a/core/src/test/java/tech/illuin/pipeline/step/MultiResultTest.java
+++ b/core/src/test/java/tech/illuin/pipeline/step/MultiResultTest.java
@@ -1,0 +1,69 @@
+package tech.illuin.pipeline.step;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import tech.illuin.pipeline.Pipeline;
+import tech.illuin.pipeline.context.Context;
+import tech.illuin.pipeline.generic.pipeline.TestResult;
+import tech.illuin.pipeline.generic.pipeline.step.TestMultiStep;
+import tech.illuin.pipeline.generic.pipeline.step.TestStep;
+import tech.illuin.pipeline.output.Output;
+import tech.illuin.pipeline.sink.Sink;
+import tech.illuin.pipeline.step.execution.condition.MetadataCondition;
+import tech.illuin.pipeline.step.result.Result;
+import tech.illuin.pipeline.step.result.ResultView;
+import tech.illuin.pipeline.step.result.Results;
+import tech.illuin.pipeline.step.variant.InputStep;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static tech.illuin.pipeline.generic.Tests.getResultTypes;
+
+/**
+ * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
+ */
+public class MultiResultTest
+{
+    @Test
+    public void testPipeline_shouldRegisterMultiple()
+    {
+        Pipeline<?> pipeline = Assertions.assertDoesNotThrow(MultiResultTest::createMultiResultPipeline);
+        Output output = Assertions.assertDoesNotThrow(() -> pipeline.run());
+        Assertions.assertDoesNotThrow(pipeline::close);
+
+        List<String> names = output.results().stream().map(Result::name).toList();
+        List<String> statuses = output.results().stream().map(TestResult.class::cast).map(TestResult::status).toList();
+
+        Assertions.assertIterableEquals(List.of("individual", "individual", "individual", "aggregate"), names);
+        Assertions.assertIterableEquals(List.of("ok", "ko", "maybe", "ok+ko+maybe"), statuses);
+
+        Assertions.assertTrue(output.results().current("individual").isPresent());
+        Assertions.assertEquals(3, output.results().current().filter(r -> r.name().equals("individual")).count());
+        Assertions.assertTrue(output.results().current("aggregate").isPresent());
+        Assertions.assertEquals(1, output.results().current().filter(r -> r.name().equals("aggregate")).count());
+
+    }
+
+    private static Pipeline<?> createMultiResultPipeline()
+    {
+        return Pipeline.of("test-multi-result")
+           .registerStep(builder -> builder
+               .step(new TestMultiStep<>("individual", idx -> List.of("ok", "ko", "maybe")))
+           )
+           .registerStep(builder -> builder
+               .step((InputStep<Object>) (input, results, context) -> {
+                   String aggregate = results.current()
+                       .filter(p -> p instanceof TestResult)
+                       .map(TestResult.class::cast)
+                       .map(TestResult::status)
+                       .collect(Collectors.joining("+"));
+                   return new TestResult("aggregate", aggregate);
+               })
+           )
+           .build()
+        ;
+    }
+}

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -38,6 +38,12 @@ Here, the inner type is fine if it is closely tied to the `Step` logic, so it ca
 In other circumstances, you might need a common result type being its own thing.
 Together with a [`ResultEvaluator`](#result-evaluators) they can pull a lot of modeling weight.
 
+A `Step` can return several results simultaneously by using the `MultiResult` wrapper.
+Each `Result` in the wrapper will be indexed individually and considered as if they were produced by a sequence of steps.
+
+Note however that `MultiResult` outputs are considered as a single entity by any registered `ResultEvaluator`, this is so you can implement your own logic for resolving the `StepStrategy` from the result collection.
+For the same reason, if an `Interruption` is returned as part of a `MultiResult` it won't be picked up by `X_ON_INTERRUPT` default evaluator implementations. 
+
 ## Configuration
 
 `Step` functions can be supplied to a pipeline builder "as-is", meaning you simply `registerStep` the step instance itself:


### PR DESCRIPTION
Adding the `MultiResult` wrapper for returning multiple results out of a single step.