### PR TITLE
fix: Result generics in annotation based components

### DIFF
--- a/core/src/main/java/tech/illuin/pipeline/builder/ComponentBuilder.java
+++ b/core/src/main/java/tech/illuin/pipeline/builder/ComponentBuilder.java
@@ -6,7 +6,6 @@ import tech.illuin.pipeline.builder.runner_compiler.RunnerCompiler;
 import tech.illuin.pipeline.builder.runner_compiler.argument_resolver.MethodArgumentResolver;
 
 import java.lang.annotation.Annotation;
-import java.util.List;
 import java.util.Optional;
 
 /**

--- a/core/src/main/java/tech/illuin/pipeline/commons/Reflection.java
+++ b/core/src/main/java/tech/illuin/pipeline/commons/Reflection.java
@@ -60,14 +60,14 @@ public final class Reflection
             throw new IllegalStateException("Argument of type Optional of a " + expectedSuperclass.getSimpleName() + " subtype are expected to be declared with a single explicit bound");
 
         Type typeParam = typeParams[0];
-        if (!(typeParam instanceof Class<?> typeParamClass))
+        Optional<Class<?>> typeParamClass = asClass(typeParam);
+        if (typeParamClass.isEmpty())
             throw new IllegalStateException("Argument of type Optional uses an unexpected type " + typeParam.getClass());
 
         //noinspection unchecked
-        return expectedSuperclass.isAssignableFrom(typeParamClass)
-            ? Optional.of((C) typeParamClass)
-            : Optional.empty()
-        ;
+        return typeParamClass
+            .filter(expectedSuperclass::isAssignableFrom)
+            .map(c -> (C) c);
     }
 
     public static <C extends Class<?>> Optional<C> getStreamParameter(Parameter parameter, C expectedSuperclass)
@@ -80,14 +80,14 @@ public final class Reflection
             throw new IllegalStateException("Argument of type Stream of a " + expectedSuperclass.getSimpleName() + " subtype are expected to be declared with a single explicit bound");
 
         Type typeParam = typeParams[0];
-        if (!(typeParam instanceof Class<?> typeParamClass))
+        Optional<Class<?>> typeParamClass = asClass(typeParam);
+        if (typeParamClass.isEmpty())
             throw new IllegalStateException("Argument of type Stream uses an unexpected type " + typeParam.getClass());
 
         //noinspection unchecked
-        return expectedSuperclass.isAssignableFrom(typeParamClass)
-            ? Optional.of((C) typeParamClass)
-            : Optional.empty()
-        ;
+        return typeParamClass
+            .filter(expectedSuperclass::isAssignableFrom)
+            .map(c -> (C) c);
     }
 
     public static Class<?> getWrapperType(Class<?> primitiveType)
@@ -96,5 +96,14 @@ public final class Reflection
             throw new IllegalArgumentException("The provided type is not a primitive type");
 
         return PRIMITIVE_MAP.get(primitiveType);
+    }
+
+    private static Optional<Class<?>> asClass(Type type)
+    {
+        if (type instanceof Class<?> c)
+            return Optional.of(c);
+        if (type instanceof ParameterizedType p)
+            return asClass(p.getRawType());
+        return Optional.empty();
     }
 }

--- a/core/src/test/java/tech/illuin/pipeline/commons/ReflectionTest.java
+++ b/core/src/test/java/tech/illuin/pipeline/commons/ReflectionTest.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class ReflectionTest
@@ -44,7 +45,7 @@ public class ReflectionTest
     @Test
     public void testGetOptionalParameter() throws NoSuchMethodException
     {
-        Method method = ReflectionTest.class.getMethod("acceptOptional", Optional.class, Optional.class, Object.class);
+        Method method = ReflectionTest.class.getMethod("acceptOptional", Optional.class, Optional.class, Optional.class, Object.class);
 
         Parameter arg0 = method.getParameters()[0];
         Optional<Class<Object>> optionalArg0 = Assertions.assertDoesNotThrow(() -> Reflection.getOptionalParameter(arg0, Object.class));
@@ -60,6 +61,11 @@ public class ReflectionTest
         Assertions.assertTrue(optionalArg1Generic.isPresent());
         Assertions.assertEquals(ReturnTrue.class, optionalArg1Generic.get());
 
+        Parameter arg2 = method.getParameters()[2];
+        Optional<Class<Supplier>> optionalArg2 = Assertions.assertDoesNotThrow(() -> Reflection.getOptionalParameter(arg2, Supplier.class));
+        Assertions.assertTrue(optionalArg2.isPresent());
+        Assertions.assertEquals(Supplier.class, optionalArg2.get());
+
         Optional<Class<Integer>> optionalArg1Mismatch = Assertions.assertDoesNotThrow(() -> Reflection.getOptionalParameter(arg1, Integer.class));
         Assertions.assertTrue(optionalArg1Mismatch.isEmpty());
     }
@@ -67,8 +73,8 @@ public class ReflectionTest
     @Test
     public void testGetOptionalParameter__shouldReturnEmptyForNonOptional() throws NoSuchMethodException
     {
-        Method method = ReflectionTest.class.getMethod("acceptOptional", Optional.class, Optional.class, Object.class);
-        Parameter arg2 = method.getParameters()[2];
+        Method method = ReflectionTest.class.getMethod("acceptOptional", Optional.class, Optional.class, Optional.class, Object.class);
+        Parameter arg2 = method.getParameters()[3];
 
         Optional<Class<?>> optionalArg2 = Assertions.assertDoesNotThrow(() -> Reflection.getOptionalParameter(arg2, Object.class));
         Assertions.assertTrue(optionalArg2.isEmpty());
@@ -77,7 +83,7 @@ public class ReflectionTest
     @Test
     public void testGetStreamParameter() throws NoSuchMethodException
     {
-        Method method = ReflectionTest.class.getMethod("acceptStream", Stream.class, Stream.class, Object.class);
+        Method method = ReflectionTest.class.getMethod("acceptStream", Stream.class, Stream.class, Stream.class, Object.class);
 
         Parameter arg0 = method.getParameters()[0];
         Optional<Class<Object>> streamArg0 = Assertions.assertDoesNotThrow(() -> Reflection.getStreamParameter(arg0, Object.class));
@@ -93,6 +99,11 @@ public class ReflectionTest
         Assertions.assertTrue(streamArg1Generic.isPresent());
         Assertions.assertEquals(ReturnTrue.class, streamArg1Generic.get());
 
+        Parameter arg2 = method.getParameters()[2];
+        Optional<Class<Supplier>> streamArg2 = Assertions.assertDoesNotThrow(() -> Reflection.getStreamParameter(arg2, Supplier.class));
+        Assertions.assertTrue(streamArg2.isPresent());
+        Assertions.assertEquals(Supplier.class, streamArg2.get());
+
         Optional<Class<Integer>> streamArg1Mismatch = Assertions.assertDoesNotThrow(() -> Reflection.getStreamParameter(arg1, Integer.class));
         Assertions.assertTrue(streamArg1Mismatch.isEmpty());
     }
@@ -100,8 +111,8 @@ public class ReflectionTest
     @Test
     public void testGetStreamParameter__shouldReturnEmptyForNonStream() throws NoSuchMethodException
     {
-        Method method = ReflectionTest.class.getMethod("acceptStream", Stream.class, Stream.class, Object.class);
-        Parameter arg2 = method.getParameters()[2];
+        Method method = ReflectionTest.class.getMethod("acceptStream", Stream.class, Stream.class, Stream.class, Object.class);
+        Parameter arg2 = method.getParameters()[3];
 
         Optional<Class<?>> streamArg2 = Assertions.assertDoesNotThrow(() -> Reflection.getStreamParameter(arg2, Object.class));
         Assertions.assertTrue(streamArg2.isEmpty());
@@ -125,12 +136,14 @@ public class ReflectionTest
     public static void acceptOptional(
         Optional<Object> optionalObject,
         Optional<ReturnTrue> optionalTyped,
+        Optional<Supplier<Integer>> optionalGeneric,
         Object nonOptional
     ) {}
 
     public static void acceptStream(
         Stream<Object> streamObject,
         Stream<ReturnTrue> streamTyped,
+        Stream<Supplier<Integer>> streamGeneric,
         Object nonOptional
     ) {}
 }


### PR DESCRIPTION
Fixes a bug with annotation-based components where generic results could not be passed in `Optional` or `Stream` form.

e.g. the following would work:

```java
@SinkConfig
public void swap(@Current Stream<MyResult> myResults)
{
    /* do stuff */
}
```

while this, would not:

```java
@SinkConfig
public void swap(@Current Stream<MyGenericResult<?>> myResults)
{
    /* do stuff */
}
```

and instead would result in an exception being thrown:

```log
Argument of type Stream uses an unexpected type class sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
```

Same idea for `Optional<MyGenericResult<?>>`.