### PR TITLE
fix: null-checks and empty-strings

### DIFF
--- a/core/src/main/java/tech/illuin/pipeline/builder/PayloadPipelineBuilder.java
+++ b/core/src/main/java/tech/illuin/pipeline/builder/PayloadPipelineBuilder.java
@@ -90,6 +90,8 @@ public final class PayloadPipelineBuilder<I>
             throw new IllegalStateException("A payload-based pipeline cannot be built without an initializer");
         if (this.indexers().isEmpty())
             this.indexers.add(new SingleAutoIndexer<>());
+        if (this.id == null)
+            throw new IllegalStateException("The pipeline id cannot be null");
 
         return new CompositePipeline<>(
             this.id(),

--- a/core/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerBuilder.java
+++ b/core/src/main/java/tech/illuin/pipeline/input/initializer/builder/InitializerBuilder.java
@@ -90,11 +90,18 @@ public class InitializerBuilder<I> extends ComponentBuilder<Object, I, Initializ
         config.ifPresent(this::fillFromAnnotation);
 
         this.fillDefaults();
+        this.validate();
 
         return new InitializerDescriptor<>(
             this.id,
             this.initializer,
             this.errorHandler
         );
+    }
+
+    private void validate()
+    {
+        if (this.id == null)
+            throw new IllegalStateException("An initializer cannot have a null id, make sure the defaultId() return value is not null");
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/metering/PipelineMetrics.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/PipelineMetrics.java
@@ -11,6 +11,7 @@ import tech.illuin.pipeline.metering.tag.MetricTags;
 import tech.illuin.pipeline.output.PipelineTag;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -91,12 +92,13 @@ public class PipelineMetrics extends MDCMarker
     @Override
     public Map<String, String> compileMarkers()
     {
+        Map<String, String> markers = new HashMap<>();
+        markers.put("pipeline", this.tag.pipeline());
+        /* The author value can be null, thus Map.of cannot be used here */
+        markers.put("author", this.tag.author());
         return MetricFunctions.compileMarkers(
             this.metricTags,
-            Map.of(
-                "pipeline", this.tag.pipeline(),
-                "author", this.tag.author()
-            ),
+            markers,
             emptyMap()
         );
     }

--- a/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricTags.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricTags.java
@@ -54,6 +54,8 @@ public final class MetricTags
 
     public Collection<Tag> asTags()
     {
-        return this.data.entrySet().stream().map(e -> Tag.of(e.getKey(), e.getValue())).toList();
+        return this.data.entrySet().stream()
+            .map(e -> Tag.of(e.getKey(), e.getValue() == null ? "" : e.getValue()))
+            .toList();
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/sink/builder/SinkBuilder.java
+++ b/core/src/main/java/tech/illuin/pipeline/sink/builder/SinkBuilder.java
@@ -111,6 +111,7 @@ public class SinkBuilder extends ComponentBuilder<Object, Object, SinkDescriptor
         config.ifPresent(this::fillFromAnnotation);
 
         this.fillDefaults();
+        this.validate();
 
         return new SinkDescriptor(
             this.id,
@@ -119,5 +120,11 @@ public class SinkBuilder extends ComponentBuilder<Object, Object, SinkDescriptor
             this.executionWrapper,
             this.errorHandler
         );
+    }
+
+    private void validate()
+    {
+        if (this.id == null)
+            throw new IllegalStateException("A sink cannot have a null id, make sure the defaultId() return value is not null");
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/step/builder/StepBuilder.java
+++ b/core/src/main/java/tech/illuin/pipeline/step/builder/StepBuilder.java
@@ -177,6 +177,7 @@ public class StepBuilder<T extends Indexable, I> extends ComponentBuilder<T, I, 
         config.ifPresent(this::fillFromAnnotation);
 
         this.fillDefaults();
+        this.validate();
 
         return new StepDescriptor<>(
             this.id,
@@ -187,5 +188,11 @@ public class StepBuilder<T extends Indexable, I> extends ComponentBuilder<T, I, 
             this.resultEvaluator,
             this.errorHandler
         );
+    }
+
+    private void validate()
+    {
+        if (this.id == null)
+            throw new IllegalStateException("A step cannot have a null id, make sure the defaultId() return value is not null");
     }
 }

--- a/core/src/test/java/tech/illuin/pipeline/metrics/PipelineMetricsTest.java
+++ b/core/src/test/java/tech/illuin/pipeline/metrics/PipelineMetricsTest.java
@@ -59,6 +59,28 @@ public class PipelineMetricsTest
     }
 
     @Test
+    public void testMDC_shouldHandleNulls()
+    {
+        MDCAdapter adapter = new BasicMDCAdapter();
+        PipelineMetrics metrics = Assertions.assertDoesNotThrow(() -> new PipelineMetrics(
+            new SimpleMeterRegistry(),
+            new PipelineTag(TSIDGenerator.INSTANCE.generate(), "test-mdc-nullable", null),
+            new MetricTags().put("test", "true"),
+            new DebugMDCManager(adapter)
+        ));
+
+        metrics.setMDC();
+        Map<String, String> ctx0 = adapter.getCopyOfContextMap();
+
+        Assertions.assertTrue(ctx0.containsKey("pipeline"));
+        Assertions.assertTrue(ctx0.containsKey("author"));
+        Assertions.assertTrue(ctx0.containsKey("test"));
+        Assertions.assertEquals("test-mdc-nullable", ctx0.get("pipeline"));
+        Assertions.assertNull(ctx0.get("author"));
+        Assertions.assertEquals("true", ctx0.get("test"));
+    }
+
+    @Test
     public void testMDCException()
     {
         MDCAdapter adapter = new BasicMDCAdapter();

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) %green(%mdc) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="tech.illuin" level="DEBUG" />
+    <logger name="tech.illuin.pipeline" level="TRACE" />
+    <logger name="dev.illuin" level="INFO" />
+    <logger name="io.micrometer.core" level="INFO" />
+</configuration>

--- a/core/src/test/resources/simplelogger.properties
+++ b/core/src/test/resources/simplelogger.properties
@@ -1,6 +1,0 @@
-org.slf4j.simpleLogger.showShortLogName=true
-org.slf4j.simpleLogger.defaultLogLevel=OFF
-org.slf4j.simpleLogger.log.tech.illuin=DEBUG
-org.slf4j.simpleLogger.log.tech.illuin.pipeline=TRACE
-org.slf4j.simpleLogger.log.dev.illuin=INFO
-org.slf4j.simpleLogger.log.io.micrometer.core=INFO

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <logback.version>1.5.16</logback.version>
         <junit.version>5.11.4</junit.version>
         <mockito.version>5.15.2</mockito.version>
         <jacoco.version>0.8.12</jacoco.version>
@@ -85,9 +86,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/resilience4j/src/test/resources/logback-test.xml
+++ b/resilience4j/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) %green(%mdc) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="tech.illuin" level="DEBUG" />
+    <logger name="tech.illuin.pipeline" level="TRACE" />
+    <logger name="dev.illuin" level="INFO" />
+    <logger name="io.micrometer.core" level="INFO" />
+</configuration>

--- a/resilience4j/src/test/resources/simplelogger.properties
+++ b/resilience4j/src/test/resources/simplelogger.properties
@@ -1,6 +1,0 @@
-org.slf4j.simpleLogger.showShortLogName=true
-org.slf4j.simpleLogger.defaultLogLevel=OFF
-org.slf4j.simpleLogger.log.tech.illuin=DEBUG
-org.slf4j.simpleLogger.log.tech.illuin.pipeline=TRACE
-org.slf4j.simpleLogger.log.dev.illuin=INFO
-org.slf4j.simpleLogger.log.io.micrometer.core=INFO


### PR DESCRIPTION
* adding null-checks on null ids during component build
* mapping user-provided null metric tags entries to empty strings for micrometer `Tag` compatibility
* switching test logging backend from simple-logger to logback