### PR TITLE
feat: adding default set of counters for retry wrappers

### DIFF
--- a/core/src/main/java/tech/illuin/pipeline/metering/MeterRegistryKey.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/MeterRegistryKey.java
@@ -40,12 +40,12 @@ public enum MeterRegistryKey
     
     private final String id;
 
-    private static final Map<MeterRegistryKey, Set<String>> REGISTERED_LABELS;
+    private static final Map<String, Set<String>> REGISTERED_LABELS;
 
     static {
         REGISTERED_LABELS = new ConcurrentHashMap<>();
         for (MeterRegistryKey key : MeterRegistryKey.values())
-            REGISTERED_LABELS.put(key, new ConcurrentSkipListSet<>());
+            REGISTERED_LABELS.put(key.name(), new ConcurrentSkipListSet<>());
     }
 
     MeterRegistryKey(String id)
@@ -70,10 +70,10 @@ public enum MeterRegistryKey
      * @param tags a list of tags to be applied to a metric
      * @return the filled out tag list
      */
-    public static List<Tag> fill(MeterRegistryKey key, Collection<Tag> tags)
+    public static List<Tag> fill(String key, Collection<Tag> tags)
     {
         Map<String, String> map = new HashMap<>();
-        Set<String> pastLabels = REGISTERED_LABELS.get(key);
+        Set<String> pastLabels = REGISTERED_LABELS.computeIfAbsent(key, k -> new ConcurrentSkipListSet<>());
         for (String label : pastLabels)
             map.put(label, "");
         for (Tag tag : tags)
@@ -82,5 +82,10 @@ public enum MeterRegistryKey
             pastLabels.add(tag.getKey());
         }
         return map.entrySet().stream().map(e -> Tag.of(e.getKey(), e.getValue())).toList();
+    }
+
+    public static List<Tag> fill(MeterRegistryKey key, Collection<Tag> tags)
+    {
+        return fill(key.name(), tags);
     }
 }

--- a/resilience4j/src/main/java/tech/illuin/pipeline/resilience4j/sink/wrapper/retry/RetrySink.java
+++ b/resilience4j/src/main/java/tech/illuin/pipeline/resilience4j/sink/wrapper/retry/RetrySink.java
@@ -1,6 +1,9 @@
 package tech.illuin.pipeline.resilience4j.sink.wrapper.retry;
 
 import io.github.resilience4j.retry.Retry;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import org.slf4j.MDC;
 import tech.illuin.pipeline.context.LocalContext;
 import tech.illuin.pipeline.output.Output;
@@ -10,6 +13,8 @@ import tech.illuin.pipeline.sink.execution.wrapper.SinkWrapperException;
 
 import java.util.Map;
 
+import static tech.illuin.pipeline.metering.MeterRegistryKey.fill;
+
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
@@ -17,6 +22,13 @@ public class RetrySink implements Sink
 {
     private final Sink sink;
     private final Retry retry;
+
+    public static final String RUN_COUNT_KEY = "pipeline.sink.retry.run_count";
+    public static final String RETRY_COUNT_KEY = "pipeline.sink.retry.retry_count";
+    public static final String RUN_SUCCESS_KEY = "pipeline.sink.retry.run_success";
+    public static final String RETRY_SUCCESS_KEY = "pipeline.sink.retry.retry_success";
+    public static final String RUN_FAILURE_KEY = "pipeline.sink.retry.run_failure";
+    public static final String RETRY_FAILURE_KEY = "pipeline.sink.retry.retry_failure";
 
     public RetrySink(Sink sink, Retry retry)
     {
@@ -34,12 +46,19 @@ public class RetrySink implements Sink
                 MDC.setContextMap(mdc);
                 return executeSink(output, context);
             });
+
+            counter(RUN_SUCCESS_KEY, context).increment();
         }
         catch (SinkWrapperException e) {
+            counter(RUN_FAILURE_KEY, context, Tag.of("error", e.getClass().getName())).increment();
             throw (Exception) e.getCause();
         }
         catch (Exception e) {
+            counter(RUN_FAILURE_KEY, context, Tag.of("error", e.getClass().getName())).increment();
             throw new RetryException(e.getMessage(), e);
+        }
+        finally {
+            counter(RUN_COUNT_KEY, context).increment();
         }
     }
 
@@ -48,11 +67,22 @@ public class RetrySink implements Sink
     {
         try {
             this.sink.execute(output, context);
+            counter(RETRY_SUCCESS_KEY, context).increment();
             return true;
         }
         catch (Exception e) {
+            counter(RETRY_FAILURE_KEY, context, Tag.of("error", e.getClass().getName())).increment();
             throw new SinkWrapperException(e);
         }
+        finally {
+            counter(RETRY_COUNT_KEY, context).increment();
+        }
+    }
+
+    private static Counter counter(String key, LocalContext context, Tag... tags)
+    {
+        MeterRegistry registry = context.observabilityManager().meterRegistry();
+        return registry.counter(key, fill(key, context.markerManager().tags(tags)));
     }
 
     @Override


### PR DESCRIPTION
Additions:
* adding default set of counters for retry wrappers (`RetryStep` and `RetrySink`)
* MeterRegistryKey can now fill-in counters with arbitrary ids

Additional metrics for steps are the following:
* `pipeline.step.retry.run_count` (count) : how many times the wrapper was executed
* `pipeline.step.retry.run_success` (count) : how many times the wrapper succeeded
* `pipeline.step.retry.run_failure` (count) : how many times the wrapper failed (retry exhausted)
* `pipeline.step.retry.retry_count` (count) : how many times a retry was attempted
* `pipeline.step.retry.retry_success` (count) : how many times a retry attempt succeeded
* `pipeline.step.retry.retry_failure` (count) : how many times a retry attempt failed

Additional metrics for sinks are the following:
* `pipeline.sink.retry.run_count` (count) : how many times the wrapper was executed
* `pipeline.sink.retry.run_success` (count) : how many times the wrapper succeeded
* `pipeline.sink.retry.run_failure` (count) : how many times the wrapper failed (retry exhausted)
* `pipeline.sink.retry.retry_count` (count) : how many times a retry was attempted
* `pipeline.sink.retry.retry_success` (count) : how many times a retry attempt succeeded
* `pipeline.sink.retry.retry_failure` (count) : how many times a retry attempt failed