### PR TITLE
feat: introducing tag scoping

### DIFF
--- a/core/src/main/java/tech/illuin/pipeline/CompositePipeline.java
+++ b/core/src/main/java/tech/illuin/pipeline/CompositePipeline.java
@@ -133,6 +133,7 @@ public final class CompositePipeline<I> implements Pipeline<I>
         {
             span.tag("uid", tag.uid());
             span.tag("input_type", io.input() == null ? "null" : io.input().getClass().getName());
+            metricTags.asMarker().forEach(span::tag);
 
             logger.debug("{}: launching pipeline over input of type {}", this.id(), input != null ? input.getClass().getName() : "null");
 

--- a/core/src/main/java/tech/illuin/pipeline/CompositePipeline.java
+++ b/core/src/main/java/tech/illuin/pipeline/CompositePipeline.java
@@ -120,7 +120,8 @@ public final class CompositePipeline<I> implements Pipeline<I>
     public Output run(I input, Context context) throws PipelineException
     {
         PipelineTag tag = this.createTag(input, context);
-        MetricTags metricTags = this.tagResolver.resolve(input, context);
+        MetricTags metricTags = new MetricTags();
+        this.tagResolver.resolve(metricTags, input, context);
         PipelineMarkerManager markerManager = new PipelineMarkerManager(tag, metricTags);
         PipelineMetrics metrics = new PipelineMetrics(this.observabilityManager.meterRegistry(), markerManager);
         IO<I> io = new IO<>(tag, input);

--- a/core/src/main/java/tech/illuin/pipeline/builder/PayloadPipelineBuilder.java
+++ b/core/src/main/java/tech/illuin/pipeline/builder/PayloadPipelineBuilder.java
@@ -112,7 +112,7 @@ public final class PayloadPipelineBuilder<I>
             this.closeTimeout(),
             this.onCloseHandlers(),
             this.observabilityManagerBuilder.build(),
-            this.tagResolver() == null ? (in, ctx) -> new MetricTags() : this.tagResolver(),
+            this.tagResolver() == null ? (metrics, in, ctx) -> new MetricTags() : this.tagResolver(),
             this.observers()
         );
     }

--- a/core/src/main/java/tech/illuin/pipeline/builder/SimplePipelineBuilder.java
+++ b/core/src/main/java/tech/illuin/pipeline/builder/SimplePipelineBuilder.java
@@ -100,7 +100,7 @@ public final class SimplePipelineBuilder<I>
             this.closeTimeout(),
             this.onCloseHandlers(),
             this.observabilityManagerBuilder.build(),
-            this.tagResolver() == null ? (in, ctx) -> new MetricTags() : this.tagResolver(),
+            this.tagResolver() == null ? (tags, in, ctx) -> new MetricTags() : this.tagResolver(),
             this.observers()
         );
     }

--- a/core/src/main/java/tech/illuin/pipeline/execution/phase/impl/InitializerPhase.java
+++ b/core/src/main/java/tech/illuin/pipeline/execution/phase/impl/InitializerPhase.java
@@ -61,7 +61,8 @@ public class InitializerPhase<I> implements PipelinePhase<I>
             throw new IllegalArgumentException("Runtime context cannot be null");
 
         ComponentTag tag = this.createTag(io.tag(), this.initializer);
-        MetricTags metricTags = this.tagResolver.resolve(io.input(), context);
+        MetricTags metricTags = new MetricTags();
+        this.tagResolver.resolve(metricTags, io.input(), context);
         InitializationMarkerManager markerManager = new InitializationMarkerManager(tag, metricTags);
         InitializationMetrics metrics = new InitializationMetrics(this.observabilityManager.meterRegistry(), markerManager);
         LocalContext localContext = new ComponentContext(context, io.input(), tag, this.uidGenerator, this.observabilityManager, markerManager);

--- a/core/src/main/java/tech/illuin/pipeline/metering/MetricFunctions.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/MetricFunctions.java
@@ -1,7 +1,6 @@
 package tech.illuin.pipeline.metering;
 
 import io.micrometer.core.instrument.Tag;
-import tech.illuin.pipeline.metering.tag.MetricTags;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -69,23 +68,8 @@ public final class MetricFunctions
         }
     }
 
-    public static Collection<Tag> compileTags(MetricTags metricTags, Tag... mainstayTags)
+    public static Map<String, String> compileMarkers(Map<String, String> metricTagMarkers, Map<String, String> mainstayMarkers, Map<String, String> dynamicMarkers)
     {
-        return combine(List.of(mainstayTags), metricTags.asTags());
-    }
-
-    public static Collection<Tag> compileAndFillTags(MetricTags metricTags, MeterRegistryKey key, Tag... tags)
-    {
-        return compileAndFillTags(metricTags, key, List.of(tags));
-    }
-
-    public static Collection<Tag> compileAndFillTags(MetricTags metricTags, MeterRegistryKey key, Collection<Tag> tags)
-    {
-        return MeterRegistryKey.fill(key, combine(tags, metricTags.asTags()));
-    }
-
-    public static Map<String, String> compileMarkers(MetricTags metricTags, Map<String, String> mainstayMarkers, Map<String, String> dynamicMarkers)
-    {
-        return MetricFunctions.combine(mainstayMarkers, metricTags.asMap(), dynamicMarkers);
+        return MetricFunctions.combine(mainstayMarkers, metricTagMarkers, dynamicMarkers);
     }
 }

--- a/core/src/main/java/tech/illuin/pipeline/metering/PipelineMarkerManager.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/PipelineMarkerManager.java
@@ -44,7 +44,7 @@ public class PipelineMarkerManager implements MarkerManager
         /* The author value can be null, thus Map.of cannot be used here */
         markers.put("author", this.tag.author());
         return MetricFunctions.compileMarkers(
-            this.metricTags,
+            this.metricTags.asMarker(),
             markers,
             emptyMap()
         );

--- a/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricScope.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricScope.java
@@ -1,0 +1,9 @@
+package tech.illuin.pipeline.metering.tag;
+
+public enum MetricScope
+{
+    /** MARKER scoped tags will be used in MDC and other potentially high-cardinality scenarios */
+    MARKER,
+    /** TAG scoped tags will be used as Micrometer metric tags and should avoid high-cardinality scenarios */
+    TAG,
+}

--- a/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricTags.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricTags.java
@@ -26,9 +26,19 @@ public final class MetricTags
         return this.data.containsKey(key);
     }
 
+    public boolean has(String key, MetricScope scope)
+    {
+        return this.get(key, scope).isPresent();
+    }
+
     public <E extends Enum<E>> boolean has(E key)
     {
         return this.has(key.name());
+    }
+
+    public <E extends Enum<E>> boolean has(E key, MetricScope scope)
+    {
+        return this.has(key.name(), scope);
     }
 
     public Optional<String> get(String key)
@@ -36,9 +46,22 @@ public final class MetricTags
         return Optional.ofNullable(this.data.get(key)).map(ScopedTag::value);
     }
 
+    public Optional<String> get(String key, MetricScope scope)
+    {
+        ScopedTag tag = this.data.get(key);
+        if (tag != null && tag.scopes.contains(scope))
+            return Optional.ofNullable(tag.value);
+        return Optional.empty();
+    }
+
     public <E extends Enum<E>> Optional<String> get(E key)
     {
         return this.get(key.name());
+    }
+
+    public <E extends Enum<E>> Optional<String> get(E key, MetricScope scope)
+    {
+        return this.get(key.name(), scope);
     }
 
     public MetricTags put(String key, String value)

--- a/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricTags.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricTags.java
@@ -3,13 +3,18 @@ package tech.illuin.pipeline.metering.tag;
 import io.micrometer.core.instrument.Tag;
 
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static tech.illuin.pipeline.metering.tag.MetricScope.MARKER;
+import static tech.illuin.pipeline.metering.tag.MetricScope.TAG;
 
 /**
  * @author Pierre Lecerf (pierre.lecerf@illuin.tech)
  */
 public final class MetricTags
 {
-    private final Map<String, String> data;
+    private final Map<String, ScopedTag> data;
 
     public MetricTags()
     {
@@ -28,7 +33,7 @@ public final class MetricTags
 
     public Optional<String> get(String key)
     {
-        return Optional.ofNullable(this.data.get(key));
+        return Optional.ofNullable(this.data.get(key)).map(ScopedTag::value);
     }
 
     public <E extends Enum<E>> Optional<String> get(E key)
@@ -38,7 +43,13 @@ public final class MetricTags
 
     public MetricTags put(String key, String value)
     {
-        this.data.put(key, value);
+        this.put(key, value, MetricScope.values());
+        return this;
+    }
+
+    public MetricTags put(String key, String value, MetricScope... scopes)
+    {
+        this.data.put(key, new ScopedTag(value, Set.of(scopes)));
         return this;
     }
 
@@ -49,13 +60,37 @@ public final class MetricTags
 
     public Map<String, String> asMap()
     {
-        return Collections.unmodifiableMap(this.data);
+        return this.data.entrySet().stream()
+            .collect(Collectors.toUnmodifiableMap(
+                Map.Entry::getKey,
+                e -> e.getValue().value()
+            ));
+    }
+
+    public Map<String, String> asMarker()
+    {
+        return this.filterData(MARKER)
+            .collect(Collectors.toUnmodifiableMap(
+                Map.Entry::getKey,
+                e -> e.getValue().value()
+            ));
     }
 
     public Collection<Tag> asTags()
     {
-        return this.data.entrySet().stream()
-            .map(e -> Tag.of(e.getKey(), e.getValue() == null ? "" : e.getValue()))
+        return this.filterData(TAG)
+            .map(e -> Tag.of(e.getKey(), e.getValue().value() == null ? "" : e.getValue().value()))
             .toList();
     }
+
+    private Stream<Map.Entry<String, ScopedTag>> filterData(MetricScope scope)
+    {
+        return this.data.entrySet().stream()
+            .filter(e -> e.getValue().scopes().contains(scope));
+    }
+
+    private record ScopedTag(
+        String value,
+        Set<MetricScope> scopes
+    ) {}
 }

--- a/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricTags.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/tag/MetricTags.java
@@ -81,6 +81,11 @@ public final class MetricTags
         return this.put(key.name(), value);
     }
 
+    public <E extends Enum<E>> MetricTags put(E key, String value, MetricScope... scopes)
+    {
+        return this.put(key.name(), value, scopes);
+    }
+
     public Map<String, String> asMap()
     {
         return this.data.entrySet().stream()

--- a/core/src/main/java/tech/illuin/pipeline/metering/tag/TagResolver.java
+++ b/core/src/main/java/tech/illuin/pipeline/metering/tag/TagResolver.java
@@ -7,5 +7,5 @@ import tech.illuin.pipeline.context.Context;
  */
 public interface TagResolver<T>
 {
-    MetricTags resolve(T input, Context context);
+    void resolve(MetricTags tags, T input, Context context);
 }

--- a/core/src/test/java/tech/illuin/pipeline/metrics/MetricTagsTest.java
+++ b/core/src/test/java/tech/illuin/pipeline/metrics/MetricTagsTest.java
@@ -1,0 +1,61 @@
+package tech.illuin.pipeline.metrics;
+
+import io.micrometer.core.instrument.Tag;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import tech.illuin.pipeline.metering.tag.MetricScope;
+import tech.illuin.pipeline.metering.tag.MetricTags;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class MetricTagsTest
+{
+    @Test
+    public void test__empty()
+    {
+        var metricTags = new MetricTags();
+
+        Map<String, String> map = Assertions.assertDoesNotThrow(metricTags::asMap);
+        Assertions.assertTrue(map.isEmpty());
+
+        Collection<Tag> tags = Assertions.assertDoesNotThrow(metricTags::asTags);
+        Assertions.assertTrue(tags.isEmpty());
+
+        Map<String, String> markers = Assertions.assertDoesNotThrow(metricTags::asMarker);
+        Assertions.assertTrue(markers.isEmpty());
+    }
+
+    @Test
+    public void test__scoped()
+    {
+        var metricTags = new MetricTags();
+        metricTags.put("a", "anything-goes");
+        metricTags.put("b", "high-cardinality", MetricScope.MARKER);
+        metricTags.put("c", "low-cardinality", MetricScope.TAG);
+
+        Assertions.assertTrue(metricTags.has("a", MetricScope.MARKER));
+        Assertions.assertTrue(metricTags.has("a", MetricScope.TAG));
+        Assertions.assertEquals("anything-goes", metricTags.get("a", MetricScope.MARKER).orElse(null));
+        Assertions.assertEquals("anything-goes", metricTags.get("a", MetricScope.TAG).orElse(null));
+
+        Assertions.assertTrue(metricTags.has("b", MetricScope.MARKER));
+        Assertions.assertFalse(metricTags.has("b", MetricScope.TAG));
+        Assertions.assertEquals("high-cardinality", metricTags.get("b", MetricScope.MARKER).orElse(null));
+        Assertions.assertTrue(metricTags.get("b", MetricScope.TAG).isEmpty());
+
+        Assertions.assertFalse(metricTags.has("c", MetricScope.MARKER));
+        Assertions.assertTrue(metricTags.has("c", MetricScope.TAG));
+        Assertions.assertTrue(metricTags.get("c", MetricScope.MARKER).isEmpty());
+        Assertions.assertEquals("low-cardinality", metricTags.get("c", MetricScope.TAG).orElse(null));
+
+        Map<String, String> map = Assertions.assertDoesNotThrow(metricTags::asMap);
+        Assertions.assertEquals(3, map.size());
+
+        Collection<Tag> tags = Assertions.assertDoesNotThrow(metricTags::asTags);
+        Assertions.assertEquals(2, tags.size());
+
+        Map<String, String> markers = Assertions.assertDoesNotThrow(metricTags::asMarker);
+        Assertions.assertEquals(2, markers.size());
+    }
+}

--- a/doc/modifiers_and_hooks.md
+++ b/doc/modifiers_and_hooks.md
@@ -186,9 +186,9 @@ A typical `TagResolver` may look like this:
 public class MyTagResolver implements TagResolver<MyInputType>
 {
     @Override
-    public MetricTags resolve(MyInputType input, Context context)
+    public void resolve(MetricTags tags, MyInputType input, Context context)
     {
-        return new MetricTags()
+        tags
             .put("some_tag", input.getSome())
             .put("other_tag", input.getOther())
         ;
@@ -219,4 +219,16 @@ Log labels
   author    anonymous
   some_tag  123
   other_tag abc
+```
+
+When registering tags in a `TagResolver`, it is also possible to specify the scopes in which they should be used, at the time of this writing there are two scopes:
+
+* `MARKER`: can be used for high-cardinality values (e.g., user/entity UIDs being processed) and will end up in the MDC and tracing span tags
+* `TAG`: can be used for low-cardinality values, they will end-up as metric labels (e.g., Prometheus metric labels), where high-cardinality values can negatively impact performance
+
+Scoping a tag is done the following way:
+
+```java
+//MetricTags tags
+tags.put("my_user_uid", someUUID, MetricScope.MARKER);
 ```


### PR DESCRIPTION
Introduces a scoping mechanism for the `TagResolver`, makes it possible to have tags that are only used as "markers" (high-cardinality, such as MDC tags) or "tags" (low-cardinality, such as prometheus labels).