### PR TITLE
chore(deps): micronaut-admin bump micronaut to latest 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /data
 *.iml
 .idea
+.junie
 .java-version
 **/src/test/java/Throwaway*
 **/src/test/java/dev

--- a/admin-micronaut/pom.xml
+++ b/admin-micronaut/pom.xml
@@ -15,8 +15,8 @@
 
     <properties>
         <micronaut-api.version>2.16.2</micronaut-api.version>
-        <micronaut.version>4.7.6</micronaut.version>
-        <micronaut-test.version>4.7.0</micronaut-test.version>
+        <micronaut.version>4.10.26</micronaut.version>
+        <micronaut-test.version>4.10.3</micronaut-test.version>
     </properties>
 
     <dependencies>
@@ -112,6 +112,11 @@
                             <groupId>io.micronaut.serde</groupId>
                             <artifactId>micronaut-serde-processor</artifactId>
                             <version>${micronaut-api.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-core</artifactId>
+                            <version>${micronaut.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>2.0.18</slf4j.version>
         <logback.version>1.5.34</logback.version>
-        <junit.version>5.11.4</junit.version>
+        <junit.version>5.14.0</junit.version>
         <mockito.version>5.15.2</mockito.version>
         <jacoco.version>0.8.14</jacoco.version>
         <checkstyle.version>13.5.0</checkstyle.version>


### PR DESCRIPTION
Temporarily avoiding micronaut 5.x due to java version restrictions, for now we intend to keep compatibility with 17+.

Code/API should be compatible with 5.x so it can be used on the client side.